### PR TITLE
Adjust margin of the card footer

### DIFF
--- a/app/assets/stylesheets/mobile/loginSelectionButtonComponentStyles.js
+++ b/app/assets/stylesheets/mobile/loginSelectionButtonComponentStyles.js
@@ -36,8 +36,8 @@ const loginSelectionButtonComponentStyles = StyleSheet.create({
   },
   audioBtn: {
     borderWidth: 0,
-    borderRadius: 0,
-    width: componentUtil.pressableItemSize(10)
+    elevation: 0,
+    width: componentUtil.pressableItemSize(10),
   }
 });
 

--- a/app/assets/stylesheets/mobile/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/mobile/tiltedCardComponentStyles.js
@@ -39,10 +39,10 @@ const tiltedCardComponentStyles = StyleSheet.create({
   title: {
     fontSize: cardTitleFontSize,
     flex: 1,
+    paddingHorizontal: 8,
   },
   footer: {
     flex: 3,
-    paddingHorizontal: 8,
     paddingTop: 8
   }
 });

--- a/app/assets/stylesheets/tablet/cardPointAndAudioFooterComponentStyles.js
+++ b/app/assets/stylesheets/tablet/cardPointAndAudioFooterComponentStyles.js
@@ -6,6 +6,8 @@ const cardPointAndAudioFooterComponentStyles = StyleSheet.create({
   container: {
     alignItems: 'center',
     flexDirection: 'row',
+    paddingRight: 3,
+    paddingVertical: 2,
   },
   label: {
     color: color.blackColor,

--- a/app/assets/stylesheets/tablet/loginSelectionButtonComponentStyles.js
+++ b/app/assets/stylesheets/tablet/loginSelectionButtonComponentStyles.js
@@ -35,7 +35,7 @@ const loginSelectionButtonComponentStyles = StyleSheet.create({
   },
   audioBtn: {
     borderWidth: 0,
-    borderRadius: 0,
+    elevation: 0,
     width: componentUtil.pressableItemSize(10)
   }
 });

--- a/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
@@ -43,7 +43,6 @@ const tiltedCardComponentStyles = StyleSheet.create({
   },
   footer: {
     flex: 3,
-    paddingHorizontal: 8,
     paddingTop: 8
   }
 });

--- a/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
@@ -39,7 +39,8 @@ const tiltedCardComponentStyles = StyleSheet.create({
   title: {
     fontSize: cardTitleFontSize,
     flex: 1,
-    lineHeight: 27
+    lineHeight: 27,
+    paddingHorizontal: 8,
   },
   footer: {
     flex: 3,

--- a/app/components/loginSelections/LoginSelectionButtonComponent.js
+++ b/app/components/loginSelections/LoginSelectionButtonComponent.js
@@ -1,7 +1,6 @@
 import React, {useState} from 'react';
 import {TouchableOpacity} from 'react-native';
 import FeatherIcon from 'react-native-vector-icons/Feather';
-import IonIcon from 'react-native-vector-icons/Ionicons';
 
 import GradientViewComponent from '../shared/GradientViewComponent';
 import BoldLabelComponent from '../shared/BoldLabelComponent';
@@ -18,19 +17,17 @@ const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 const LoginSelectionButtonComponent = (props) => {
   const [disabled, setDisabled] = useState(false);
   const renderAudioButton = () => {
-    return <PlayAudioComponent
-              playIcon='volume-high-outline'
-              pauseIcon='pause'
-              muteIcon='volume-mute-outline'
-              iconSize={24}
-              audio={props.audio}
-              btnStyle={styles.audioBtn}
-              itemUuid={props.uuid}
-              playingUuid={props.playingUuid}
-              updatePlayingUuid={props.updatePlayingUuid}
-           >
-              <IonIcon/>
-           </PlayAudioComponent>
+    return (
+      <PlayAudioComponent
+        iconSize={24}
+        audio={props.audio}
+        btnStyle={styles.audioBtn}
+        itemUuid={props.uuid}
+        playingUuid={props.playingUuid}
+        isSpeakerIcon={true}
+        updatePlayingUuid={props.updatePlayingUuid}
+      />
+    )
   }
 
   const renderGradientIcon = () => {

--- a/app/components/shared/AudioWaveButtonComponent.js
+++ b/app/components/shared/AudioWaveButtonComponent.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { View, StyleSheet } from 'react-native';
-import FeatherIcon from 'react-native-vector-icons/Feather';
 
 import AudioWaveButtonRippleComponent from './audioWaveButtons/AudioWaveButtonRippleComponent';
 import PlayAudioComponent from './PlayAudioComponent';
@@ -13,22 +12,18 @@ const AudioWaveButtonComponent = (props) => {
   const [isPlaying, setIsPlaying] = useState(false);
   return (
     <View style={[styles.center, props.containerStyle]}>
-      <AudioWaveButtonRippleComponent size={size} isPlaying={isPlaying} />
+      <AudioWaveButtonRippleComponent size={size} isPlaying={isPlaying} rippleStyle={props.rippleStyle} />
       <PlayAudioComponent
-        playIcon='play'
-        pauseIcon='pause'
-        muteIcon='play'
         iconSize={24}
         audio={props.audio}
-        btnStyle={styles.audioBtn}
+        btnStyle={[styles.audioBtn, props.btnStyle]}
         itemUuid={props.itemUuid}
         playingUuid={props.playingUuid}
+        isSpeakerIcon={props.isSpeakerIcon}
         toggleIsPlaying={(isPlaying) => setIsPlaying(isPlaying)}
         updatePlaySeconds={props.updatePlaySeconds}
         updatePlayingUuid={props.updatePlayingUuid}
-      >
-        <FeatherIcon/>
-      </PlayAudioComponent>
+      />
     </View>
   )
 }

--- a/app/components/shared/BigButtonComponent.js
+++ b/app/components/shared/BigButtonComponent.js
@@ -31,15 +31,13 @@ const BigButtonComponent = (props) => {
       <BoldLabelComponent label={props.label} style={{ fontSize: xLargeFontSize(), color: colorSet().textColor }} />
 
       <PlayAudioComponent
-        playIcon='volume-high-outline'
-        pauseIcon='pause'
-        muteIcon='volume-mute-outline'
         iconSize={24}
         audio={props.audio}
         btnStyle={styles.audioBtn}
         iconColor={color.whiteColor}
         itemUuid={props.uuid}
         playingUuid={props.playingUuid}
+        isSpeakerIcon={true}
         updatePlayingUuid={props.updatePlayingUuid}
       >
         <IonIcon/>

--- a/app/components/shared/CardPointAndAudioFooterComponent.js
+++ b/app/components/shared/CardPointAndAudioFooterComponent.js
@@ -23,7 +23,7 @@ const CardPointAndAudioFooterComponent = (props) => {
         muteIcon='volume-mute-outline'
         iconSize={24}
         audio={props.audio}
-        btnStyle={{borderWidth: 0, borderRadius: 0}}
+        btnStyle={{borderWidth: 0, borderRadius: 0, alignItems: 'flex-end', paddingRight: 6}}
         itemUuid={props.uuid}
         playingUuid={props.playingUuid}
         updatePlayingUuid={props.updatePlayingUuid}

--- a/app/components/shared/CardPointAndAudioFooterComponent.js
+++ b/app/components/shared/CardPointAndAudioFooterComponent.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import {View, Text} from 'react-native';
 import { useTranslation } from 'react-i18next';
-import IonIcon from 'react-native-vector-icons/Ionicons';
 
-import PlayAudioComponent from './PlayAudioComponent';
+import AudioWaveButtonComponent from './AudioWaveButtonComponent';
 import {getStyleOfDevice} from '../../utils/responsive_util';
+import componentUtil from '../../utils/component_util';
 import translationHelper from '../../helpers/translation_helper';
 import tabletStyles from '../../assets/stylesheets/tablet/cardPointAndAudioFooterComponentStyles';
 import mobileStyles from '../../assets/stylesheets/mobile/cardPointAndAudioFooterComponentStyles';
@@ -13,23 +13,25 @@ const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
 const CardPointAndAudioFooterComponent = (props) => {
   const {t, i18n} = useTranslation();
-  return (
-    <View style={styles.container}>
-      <Text style={styles.label}>{translationHelper.translateNumber(props.points, i18n.language)} {t('point')}</Text>
 
-      <PlayAudioComponent
-        playIcon='volume-high-outline'
-        pauseIcon='pause'
-        muteIcon='volume-mute-outline'
-        iconSize={24}
-        audio={props.audio}
-        btnStyle={{borderWidth: 0, borderRadius: 0, alignItems: 'flex-end', paddingRight: 6}}
+  const renderAudioBtn = () => {
+    return (
+      <AudioWaveButtonComponent
         itemUuid={props.uuid}
+        audio={props.audio}
         playingUuid={props.playingUuid}
+        isSpeakerIcon={true}
+        containerStyle={{borderWidth: 0, zIndex: 10}}
         updatePlayingUuid={props.updatePlayingUuid}
-      >
-        <IonIcon/>
-      </PlayAudioComponent>
+        btnStyle={{elevation: 0, height: componentUtil.pressableItemSize(), width: componentUtil.pressableItemSize(), borderWidth: 1}}
+      />
+    )
+  }
+
+  return (
+    <View style={[styles.container, props.containerStyle]}>
+      <Text style={styles.label}>{translationHelper.translateNumber(props.points, i18n.language)} {t('point')}</Text>
+      { renderAudioBtn() }
     </View>
   )
 }

--- a/app/components/shared/PlayAudioComponent.js
+++ b/app/components/shared/PlayAudioComponent.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { TouchableOpacity, StyleSheet } from 'react-native';
 
+import PlayAudioIconComponent from './playAudios/PlayAudioIconComponent';
 import color from '../../themes/color';
 import componentUtil from '../../utils/component_util';
 import { outlinedButtonBorderWidth } from '../../constants/component_constant';
@@ -96,29 +97,11 @@ const PlayAudioComponent = (props) => {
     toggleAudio();
   }
 
-  const getIcon = () => {
-    if (!props.audio)
-      return props.muteIcon;
-
-    return isPlaying ? props.pauseIcon : props.playIcon
-  }
-
-  const getIconColor = () => {
-    if (isPlaying)
-      return color.secondaryColor;
-
-    return !!props.iconColor ? props.iconColor : color.primaryColor;
-  }
-
   return (
     <TouchableOpacity onPress={() => onPress()} style={[styles.btn, props.btnStyle]} disabled={!props.audio}>
-      {/* CloneElement is used so we can pass different type of icon and still using the same configuration */}
-      {  React.cloneElement(props.children, {
-          name: getIcon(),
-          size: props.iconSize, color: !!props.audio ? getIconColor() : color.mutedColor,
-          style: [props.iconStyle, { marginLeft: !isPlaying ? 0 : -2 }]
-        })
-      }
+      <PlayAudioIconComponent isPlaying={isPlaying} audio={props.audio} isSpeakerIcon={props.isSpeakerIcon}
+        iconStyle={props.iconStyle} iconSize={props.iconSize} iconColor={props.iconColor}
+      />
     </TouchableOpacity>
   )
 }
@@ -139,10 +122,9 @@ export default PlayAudioComponent;
 
 // How to use
 {/* <PlayAudioComponent
-  playIcon='play'
-  pauseIcon='pause'
   iconSize={24}
   audio={props.audio}
+  isSpeakerIcon={true/false}
   btnStyle={styles.audioBtn}
   itemUuid={props.itemUuid}             // uuid of the item that render on the card
   playingUuid={props.playingUuid}       // uuid of the item that is playing the audio

--- a/app/components/shared/RadioButtonComponent.js
+++ b/app/components/shared/RadioButtonComponent.js
@@ -17,7 +17,7 @@ const RadioButtonComponent = (props) => {
     return <View style={{flexDirection: 'row'}}>
             <TextComponent label={props.title} required={props.required} style={{color: color.whiteColor, fontSize: largeFontSize()}} />
             { requiredVisible &&
-              <TextComponent label={props.requiredMsg} style={{color: color.requiredColor, marginLeft: 6}} />
+              <TextComponent label={props.requiredMsg} style={{color: color.requiredColor, marginLeft: 6, fontSize: largeFontSize()}} />
             }
           </View>
   }

--- a/app/components/shared/SelectionItemAudioButtonComponent.js
+++ b/app/components/shared/SelectionItemAudioButtonComponent.js
@@ -9,14 +9,12 @@ const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
 const SelectionItemAudioButtonComponent = (props) => {
   return <PlayAudioComponent
-            playIcon='volume-high-outline'
-            pauseIcon='pause'
-            muteIcon='volume-mute-outline'
             iconSize={24}
             audio={props.audio}
             btnStyle={styles.audioBtn}
             itemUuid={props.itemUuid}
             playingUuid={props.playingUuid}
+            isSpeakerIcon={true}
             updatePlayingUuid={props.updatePlayingUuid}
           >
             <IonIcon/>

--- a/app/components/shared/TextInputWithAudioComponent.js
+++ b/app/components/shared/TextInputWithAudioComponent.js
@@ -32,14 +32,12 @@ const TextInputWithAudioComponent = (props) => {
 
   const renderAudioBtn = () => {
     return <PlayAudioComponent
-              playIcon='volume-high-outline'
-              pauseIcon='pause'
-              muteIcon='volume-mute-outline'
               iconSize={24}
               audio={props.audio}
               btnStyle={{borderWidth: 0, position: 'absolute', right: 0, borderRadius: 0}}
               itemUuid={props.uuid}
               playingUuid={props.playingUuid}
+              isSpeakerIcon={true}
               updatePlayingUuid={props.updatePlayingUuid}
             >
               <IonIcon/>

--- a/app/components/shared/TiltedCardComponent.js
+++ b/app/components/shared/TiltedCardComponent.js
@@ -36,6 +36,7 @@ const TiltedCardComponent = (props) => {
               audio={props.item.audioSource}
               playingUuid={props.playingUuid}
               updatePlayingUuid={props.updatePlayingUuid}
+              containerStyle={{paddingLeft: 8}}
             />
           </View>
         </View>

--- a/app/components/shared/audioWaveButtons/AudioWaveButtonRippleComponent.js
+++ b/app/components/shared/audioWaveButtons/AudioWaveButtonRippleComponent.js
@@ -30,7 +30,7 @@ const AudioWaveButtonRippleComponent  = (props) => {
   }, [props.isPlaying])
 
   const rippleView = (index) => {
-    return <Animated.View key={index} style={[ StyleSheet.absoluteFillObject, styles.ripple,
+    return <Animated.View key={index} style={[ StyleSheet.absoluteFillObject, styles.ripple, props.rippleStyle,
               {opacity: animations[index].opacity, transform: [{ scale: animations[index].scale }], height: props.size, width: props.size, borderRadius: props.size }
             ]} />
   }

--- a/app/components/shared/cardWithSoundWaves/CardWithSoundWaveAudioComponent.js
+++ b/app/components/shared/cardWithSoundWaves/CardWithSoundWaveAudioComponent.js
@@ -43,6 +43,7 @@ const CardWithSoundWaveAudioComponent = (props) => {
         itemUuid={props.itemUuid}
         audio={props.audio}
         playingUuid={props.playingUuid}
+        isSpeakerIcon={false}
         containerStyle={styles.btn}
         updatePlayingUuid={props.updatePlayingUuid}
         updatePlaySeconds={(seconds) => updatePlaySeconds(seconds)}

--- a/app/components/shared/genderSelections/GenderSelectionButtonComponent.js
+++ b/app/components/shared/genderSelections/GenderSelectionButtonComponent.js
@@ -16,14 +16,12 @@ const GenderSelectionButtonComponent = (props) => {
   const renderAudioButton = () => {
     return <View style={styles.audioContainer}>
             <PlayAudioComponent
-              playIcon='volume-high-outline'
-              pauseIcon='pause'
-              muteIcon='volume-mute-outline'
               iconSize={24}
               audio={props.audio}
               btnStyle={styles.audioBtn}
               itemUuid={props.uuid}
               playingUuid={props.playingUuid}
+              isSpeakerIcon={true}
               updatePlayingUuid={props.updatePlayingUuid}
             >
               <IonIcon/>

--- a/app/components/shared/playAudios/PlayAudioIconComponent.js
+++ b/app/components/shared/playAudios/PlayAudioIconComponent.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import FeatherIcon from 'react-native-vector-icons/Feather';
+import IonIcon from 'react-native-vector-icons/Ionicons';
+
+import color from '../../../themes/color';
+
+const iconSet = {
+  'ion_icon': {
+    play: 'volume-high-outline',
+    pause: 'pause',
+    mute: 'volume-mute-outline'
+  },
+  'feather': {
+    play: 'play',
+    pause: 'pause',
+    mute: 'play'
+  }
+}
+
+const PlayAudioIconComponent = (props) => {
+  const getIcon = () => {
+    const icon = props.isSpeakerIcon ? iconSet['ion_icon'] : iconSet['feather'];
+    if (!props.audio)
+      return icon.mute;
+
+    return props.isPlaying ? icon.pause : icon.play;
+  }
+
+  const getIconColor = () => {
+    return props.isPlaying ? color.secondaryColor : props.iconColor || color.primaryColor;
+  }
+
+  const renderIcon = () => {
+    return props.isSpeakerIcon ? <IonIcon/> : <FeatherIcon/>
+  }
+
+  {/* CloneElement is used so we can pass different type of icon and still using the same configuration */}
+  return (
+    React.cloneElement(renderIcon(), {
+      name: getIcon(),
+      size: props.iconSize, color: !!props.audio ? getIconColor() : color.mutedColor,
+      style: [props.iconStyle, { marginLeft: (props.isPlaying  && !props.isSpeakerIcon) ? -2 : 0 }]
+    })
+  )
+}
+
+export default PlayAudioIconComponent;

--- a/app/helpers/ripple_animation_helper.js
+++ b/app/helpers/ripple_animation_helper.js
@@ -10,7 +10,7 @@ const rippleAnimationHelper = (() => {
     animations.map((animation, index) => {
       Animated.loop(
         Animated.parallel([
-          _animatedTiming(animation.scale, 1.5, index * 400),
+          _animatedTiming(animation.scale, 1.8, index * 400),
           _animatedTiming(animation.opacity, 0, index * 400),
         ], { useNativeDriver: true })
       ).start();


### PR DESCRIPTION
This pull request is fixing the margin and adding the animation when the audio is playing to the play audio button in the card items.

Below are the screenshots of the card item with audio animation on the mobile and tablet device:
[audio with animation.zip](https://github.com/kawsangs/adolescents_app/files/9597201/audio.with.animation.zip)
