### PR TITLE
Fix the redirection when clicking on the contact via telegram

### DIFF
--- a/app/helpers/contact_helper.js
+++ b/app/helpers/contact_helper.js
@@ -15,7 +15,7 @@ const contactHelper = (() => {
       case FACEBOOK:
         return value;
       case TELEGRAM:
-        return `t.me/${value}`;
+        return `https://t.me/${value}`
       default:
         return value.replace(/\s/g, '');
     }


### PR DESCRIPTION
This pull request is fixing the redirection when clicking the button Telegram in the contact section.

- If the device does not have the Telegram app installed, it will open the browser with the user profile
- If the device already has the Telegram app installed, it will open the Telegram app and open a conversation with the username