### PR TITLE
Create mental support screen

### DIFF
--- a/app/components/mentalSupports/MentalSupportCardComponent.android.js
+++ b/app/components/mentalSupports/MentalSupportCardComponent.android.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import {View, StyleSheet} from 'react-native';
+import {Card, Text} from 'react-native-paper';
+import Icon from 'react-native-vector-icons/Feather';
+
+import color from '../../themes/color';
+import ContactIconComponent from '../shared/ContactIconComponent';
+import { cardElevation, cardBorderRadius, descriptionFontSize } from '../../constants/component_constant';
+import contactHelper from '../../helpers/contact_helper';
+import {TELEGRAM} from '../../constants/contact_constant';
+
+const MentalSupportCardComponent = (props) => {
+  return (
+    <Card mode="elevated" elevation={cardElevation} style={styles.card} onPress={() => contactHelper.openContactLink(props.channel, props.intend)}>
+      <View style={{flexDirection: 'row', flex: 1, alignItems: 'center'}}>
+        <ContactIconComponent type={props.channel} color={color.primaryColor} size={props.channel == TELEGRAM ? 30 : 40} />
+        <View style={{paddingLeft: 16, flex: 1}}>
+          <Text numberOfLines={2} style={{fontSize: descriptionFontSize}}>{props.name}</Text>
+        </View>
+        <Icon name="chevron-right" color={color.primaryColor} size={32} style={{paddingRight: 8}} />
+      </View>
+    </Card>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: cardBorderRadius,
+    height: 80,
+    marginTop: 11,
+    paddingLeft: 16
+  }
+});
+
+export default MentalSupportCardComponent;

--- a/app/components/mentalSupports/MentalSupportCardComponent.android.js
+++ b/app/components/mentalSupports/MentalSupportCardComponent.android.js
@@ -1,23 +1,31 @@
 import React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View, StyleSheet, Linking} from 'react-native';
 import {Card, Text} from 'react-native-paper';
 import Icon from 'react-native-vector-icons/Feather';
 
 import color from '../../themes/color';
 import ContactIconComponent from '../shared/ContactIconComponent';
 import { cardElevation, cardBorderRadius, descriptionFontSize } from '../../constants/component_constant';
-import contactHelper from '../../helpers/contact_helper';
+import { pageable_types } from '../../constants/visit_constant';
+import visitService from '../../services/visit_service';
 
 const MentalSupportCardComponent = (props) => {
+  const onPress = () => {
+    const visitParams = {
+      code: props.channel,
+      name: `${props.name} - ${props.channel}`,
+      parent_code: "mental_support",
+      pageable_type: pageable_types.page,
+    }
 
-  const renderIcon = () => {
-    return <ContactIconComponent type={props.channel} size={40} />
+    visitService.recordVisitAction(visitParams)
+    Linking.openURL(props.intend);
   }
 
   return (
-    <Card mode="elevated" elevation={cardElevation} style={styles.card} onPress={() => contactHelper.openContactLink(props.channel, props.intend)}>
+    <Card mode="elevated" elevation={cardElevation} style={styles.card} onPress={() => onPress()}>
       <View style={{flexDirection: 'row', flex: 1, alignItems: 'center'}}>
-        {renderIcon()}
+        <ContactIconComponent type={props.channel} size={40} />
         <View style={{paddingLeft: 16, flex: 1}}>
           <Text numberOfLines={2} style={{fontSize: descriptionFontSize}}>{props.name}</Text>
         </View>

--- a/app/components/mentalSupports/MentalSupportCardComponent.android.js
+++ b/app/components/mentalSupports/MentalSupportCardComponent.android.js
@@ -7,13 +7,17 @@ import color from '../../themes/color';
 import ContactIconComponent from '../shared/ContactIconComponent';
 import { cardElevation, cardBorderRadius, descriptionFontSize } from '../../constants/component_constant';
 import contactHelper from '../../helpers/contact_helper';
-import {TELEGRAM} from '../../constants/contact_constant';
 
 const MentalSupportCardComponent = (props) => {
+
+  const renderIcon = () => {
+    return <ContactIconComponent type={props.channel} size={40} />
+  }
+
   return (
     <Card mode="elevated" elevation={cardElevation} style={styles.card} onPress={() => contactHelper.openContactLink(props.channel, props.intend)}>
       <View style={{flexDirection: 'row', flex: 1, alignItems: 'center'}}>
-        <ContactIconComponent type={props.channel} color={color.primaryColor} size={props.channel == TELEGRAM ? 30 : 40} />
+        {renderIcon()}
         <View style={{paddingLeft: 16, flex: 1}}>
           <Text numberOfLines={2} style={{fontSize: descriptionFontSize}}>{props.name}</Text>
         </View>
@@ -29,7 +33,7 @@ const styles = StyleSheet.create({
     height: 80,
     marginTop: 11,
     paddingLeft: 16
-  }
+  },
 });
 
 export default MentalSupportCardComponent;

--- a/app/components/mentalSupports/MentalSupportCardListComponent.android.js
+++ b/app/components/mentalSupports/MentalSupportCardListComponent.android.js
@@ -1,10 +1,19 @@
 import React from 'react';
-import {View, Text} from 'react-native';
+import {View} from 'react-native';
+
+import MentalSupportCardComponent from './MentalSupportCardComponent';
+import {mentalSupportContacts} from '../../constants/mental_support_constant';
 
 const MentalSupportCardListComponent = () => {
+  const renderList = () => {
+    return mentalSupportContacts.map((mentalSupport, index) => {
+      return <MentalSupportCardComponent key={`mental-${index}`} name={mentalSupport.name} intend={mentalSupport.intend} channel={mentalSupport.channel} />
+    });
+  }
+
   return (
-    <View>
-      <Text>Mental Support Service</Text>
+    <View style={{marginTop: 8}}>
+      {renderList()}
     </View>
   )
 }

--- a/app/components/mentalSupports/MentalSupportCardListComponent.android.js
+++ b/app/components/mentalSupports/MentalSupportCardListComponent.android.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+
+const MentalSupportCardListComponent = () => {
+  return (
+    <View>
+      <Text>Mental Support Service</Text>
+    </View>
+  )
+}
+
+export default MentalSupportCardListComponent;

--- a/app/components/shared/ContactIconComponent.android.js
+++ b/app/components/shared/ContactIconComponent.android.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import FontAwesome from 'react-native-vector-icons/FontAwesome';
+import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
+import FeatherIcon from 'react-native-vector-icons/Feather';
+
+import color from '../../themes/color';
+import {contactIcons} from '../../constants/contact_constant';
+import {FEATHER, MATERIAL_COMMUNNITY} from '../../constants/icon_constant';
+
+const ContactIconComponent = (props) => {
+  if (contactIcons[props.type].type == FEATHER)
+    return <FeatherIcon name={contactIcons[props.type].name} size={props.size || 24} color={props.color || color.whiteColor} />
+  else if (contactIcons[props.type].type == MATERIAL_COMMUNNITY)
+    return <MaterialCommunityIcon name={contactIcons[props.type].name} size={props.size || 24} color={props.color || color.whiteColor} brand />
+
+  return <FontAwesome name={contactIcons[props.type].name} size={props.size || 24} color={props.color || color.whiteColor} />
+}
+
+export default ContactIconComponent;

--- a/app/components/shared/ContactIconComponent.android.js
+++ b/app/components/shared/ContactIconComponent.android.js
@@ -1,19 +1,24 @@
 import React from 'react';
+import {View} from 'react-native';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import FeatherIcon from 'react-native-vector-icons/Feather';
 
 import color from '../../themes/color';
-import {contactIcons} from '../../constants/contact_constant';
+import {contactIcons, WHATSAPP} from '../../constants/contact_constant';
 import {FEATHER, MATERIAL_COMMUNNITY} from '../../constants/icon_constant';
 
 const ContactIconComponent = (props) => {
-  if (contactIcons[props.type].type == FEATHER)
-    return <FeatherIcon name={contactIcons[props.type].name} size={props.size || 24} color={props.color || color.whiteColor} />
+  if (props.type == WHATSAPP)
+    return <View style={{width: 43, height: 43, backgroundColor: color.whatsappColor, borderRadius: 50, justifyContent: 'center', alignItems: 'center'}}>
+              <FontAwesome name={contactIcons[props.type].name} size={33} color={color.whiteColor} />
+           </View>
+  else if (contactIcons[props.type].type == FEATHER)
+    return <FeatherIcon name={contactIcons[props.type].name} size={props.size || 24} color={props.color || contactIcons[props.type].color} />
   else if (contactIcons[props.type].type == MATERIAL_COMMUNNITY)
-    return <MaterialCommunityIcon name={contactIcons[props.type].name} size={props.size || 24} color={props.color || color.whiteColor} brand />
+    return <MaterialCommunityIcon name={contactIcons[props.type].name} size={props.size || 24} color={props.color || contactIcons[props.type].color} brand />
 
-  return <FontAwesome name={contactIcons[props.type].name} size={props.size || 24} color={props.color || color.whiteColor} />
+  return <FontAwesome name={contactIcons[props.type].name} size={props.size || 24} color={props.color || contactIcons[props.type].color} />
 }
 
 export default ContactIconComponent;

--- a/app/components/shared/TiltedCardComponent.android.js
+++ b/app/components/shared/TiltedCardComponent.android.js
@@ -10,6 +10,7 @@ import Video from '../../models/Video';
 import categoryVisitService from '../../services/category_visit_service';
 import { getStyleOfDevice } from '../../utils/responsive_util';
 import categoryHelper from '../../helpers/category_helper';
+import {mentalSupportContacts} from '../../constants/mental_support_constant';
 import tabletStyles from '../../assets/stylesheets/tablet/tiltedCardComponentStyles';
 import mobileStyles from '../../assets/stylesheets/mobile/tiltedCardComponentStyles';
 import { cardElevation } from '../../constants/component_constant';
@@ -26,7 +27,7 @@ const TiltedCardComponent = (props) => {
     if (categoryHelper.isVideo(props.item))
       return Video.getAll().length;
 
-    return Category.getSubCategories(props.item.uuid).length;
+    return categoryHelper.isMentalSupport(props.item) ? mentalSupportContacts.length : Category.getSubCategories(props.item.uuid).length;
   }
 
   return (

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -7,8 +7,7 @@ export const environment = {
   defaultLanguage: KM,
   sentryDSN: '',
   encryptionKey: '',        // Use 256 bytes key
-  // apiKey: 'c7bfd9081b2e8d10a7a09c6cf32d141e',
-  apiKey: 'cfc88f68fd4562629d312c838337af39',
+  apiKey: 'c7bfd9081b2e8d10a7a09c6cf32d141e',
   isUserBasedAuth: false,
   apiVersion: 'v1',
   isUserBasedApi: false,

--- a/app/constants/contact_constant.js
+++ b/app/constants/contact_constant.js
@@ -1,4 +1,5 @@
 import {FONTAWESOME, FEATHER, MATERIAL_COMMUNNITY} from './icon_constant';
+import color from '../themes/color';
 
 export const FACEBOOK = "facebook";
 export const TELEGRAM = "telegram";
@@ -9,11 +10,11 @@ export const MESSENGER = "messenger";
 export const WHATSAPP = "whatsapp";
 
 export const contactIcons = {
-  facebook: { type: FONTAWESOME, name: "facebook-f" },
-  telegram: { type: FONTAWESOME, name: "paper-plane" },
-  phone: { type: FONTAWESOME, name: "phone" },
-  website: { type: FEATHER, name: "globe" },
-  sms: { type: MATERIAL_COMMUNNITY, name: "message-processing-outline" },
-  messenger: { type: MATERIAL_COMMUNNITY, name: "facebook-messenger" },
-  whatsapp: { type: FONTAWESOME, name: "whatsapp" }
+  facebook: { type: FONTAWESOME, name: "facebook-f", color: color.facebookColor },
+  telegram: { type: FONTAWESOME, name: "telegram", color: color.telegramColor },
+  phone: { type: FONTAWESOME, name: "phone", color: color.primaryColor },
+  website: { type: FEATHER, name: "globe", color: color.primaryColor },
+  sms: { type: MATERIAL_COMMUNNITY, name: "message-processing-outline", color: color.primaryColor },
+  messenger: { type: MATERIAL_COMMUNNITY, name: "facebook-messenger", color: color.primaryColor },
+  whatsapp: { type: FONTAWESOME, name: "whatsapp", color: color.primaryColor }
 }

--- a/app/constants/contact_constant.js
+++ b/app/constants/contact_constant.js
@@ -1,4 +1,19 @@
+import {FONTAWESOME, FEATHER, MATERIAL_COMMUNNITY} from './icon_constant';
+
 export const FACEBOOK = "facebook";
 export const TELEGRAM = "telegram";
 export const PHONE = "phone";
 export const WEBSITE = "website";
+export const SMS = "sms";
+export const MESSENGER = "messenger";
+export const WHATSAPP = "whatsapp";
+
+export const contactIcons = {
+  facebook: { type: FONTAWESOME, name: "facebook-f" },
+  telegram: { type: FONTAWESOME, name: "paper-plane" },
+  phone: { type: FONTAWESOME, name: "phone" },
+  website: { type: FEATHER, name: "globe" },
+  sms: { type: MATERIAL_COMMUNNITY, name: "message-processing-outline" },
+  messenger: { type: MATERIAL_COMMUNNITY, name: "facebook-messenger" },
+  whatsapp: { type: FONTAWESOME, name: "whatsapp" }
+}

--- a/app/constants/icon_constant.js
+++ b/app/constants/icon_constant.js
@@ -1,0 +1,3 @@
+export const FONTAWESOME = "fontawesome";
+export const FEATHER = "feather";
+export const MATERIAL_COMMUNNITY = "materialCommunity";

--- a/app/constants/mental_support_constant.js
+++ b/app/constants/mental_support_constant.js
@@ -1,0 +1,29 @@
+import {TELEGRAM, PHONE, WHATSAPP, MESSENGER, SMS} from './contact_constant';
+
+export const mentalSupportContacts = [
+  {
+    name: "Telegram របស់ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
+    intend: "+85570801395",
+    channel: TELEGRAM
+  },
+  {
+    name: "​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
+    intend: "070801395",
+    channel: PHONE
+  },
+  {
+    name: "Messenger របស់​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
+    intend: "kimsanlim",
+    channel: MESSENGER
+  },
+  {
+    name: "WhatsApp របស់​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
+    intend: "+85570801395",
+    channel: WHATSAPP
+  },
+  {
+    name: "SMS របស់​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
+    intend: "+85570801395",
+    channel: SMS
+  },
+]

--- a/app/constants/mental_support_constant.js
+++ b/app/constants/mental_support_constant.js
@@ -1,29 +1,24 @@
-import {TELEGRAM, PHONE, WHATSAPP, MESSENGER, SMS} from './contact_constant';
+import {TELEGRAM, PHONE, MESSENGER, SMS} from './contact_constant';
 
 export const mentalSupportContacts = [
   {
-    name: "Telegram របស់ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
-    intend: "+85570801395",
-    channel: TELEGRAM
-  },
-  {
-    name: "​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
-    intend: "070801395",
+    name: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280)",
+    intend: "1280",
     channel: PHONE
   },
   {
-    name: "Messenger របស់​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
-    intend: "kimsanlim",
+    name: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280)",
+    intend: "1280",
+    channel: SMS
+  },
+  {
+    name: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280)",
+    intend: "https://web.facebook.com/chc1280",
     channel: MESSENGER
   },
   {
-    name: "WhatsApp របស់​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
-    intend: "+85570801395",
-    channel: WHATSAPP
-  },
-  {
-    name: "SMS របស់​ទូរស័ព្ទ​ជំនួយ​កុមារ​កម្ពុជា",
-    intend: "+85570801395",
-    channel: SMS
+    name: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280)",
+    intend: "https://t.me/childhelplinecambodia",
+    channel: TELEGRAM
   },
 ]

--- a/app/constants/mental_support_constant.js
+++ b/app/constants/mental_support_constant.js
@@ -3,17 +3,17 @@ import {TELEGRAM, PHONE, MESSENGER, SMS} from './contact_constant';
 export const mentalSupportContacts = [
   {
     name: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280)",
-    intend: "1280",
+    intend: "tel:1280",
     channel: PHONE
   },
   {
     name: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280)",
-    intend: "1280",
+    intend: "sms:1280",
     channel: SMS
   },
   {
     name: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280)",
-    intend: "https://web.facebook.com/chc1280",
+    intend: "http://m.me/chc1280",
     channel: MESSENGER
   },
   {

--- a/app/helpers/contact_helper.js
+++ b/app/helpers/contact_helper.js
@@ -1,5 +1,5 @@
 import {Linking} from 'react-native';
-import { PHONE, FACEBOOK, TELEGRAM } from '../constants/contact_constant';
+import { PHONE, FACEBOOK, TELEGRAM, MESSENGER, SMS, WHATSAPP } from '../constants/contact_constant';
 
 const contactHelper = (() => {
   return {
@@ -9,16 +9,19 @@ const contactHelper = (() => {
   };
 
   function getContactLink(type, value) {
-    switch (type.toLowerCase()) {
-      case PHONE:
-        return `tel:${value}`;
-      case FACEBOOK:
-        return value;
-      case TELEGRAM:
-        return `https://t.me/${value}`
-      default:
-        return value.replace(/\s/g, '');
+    if (value.includes("http")) return value;
+
+    const contactLinks = {
+      phone: `tel:${value}`,
+      facebook: value,
+      telegram: `https://t.me/${value}`,
+      messenger: `http://m.me/${value}`,
+      whatsapp: `https://wa.me/${value}`,
+      sms: `sms:${value}`,
+      website: value.replace(/\s/g, ''),
     }
+
+    return !!contactLinks[type] ? contactLinks[type] : value;
   }
 
   function openContactLink(type, value) {

--- a/app/navigators/home_stack_navigator.js
+++ b/app/navigators/home_stack_navigator.js
@@ -6,6 +6,7 @@ import SubCategoryView from '../views/subCategories/SubCategoryView';
 import LeafCategoryView from '../views/leafCategories/LeafCategoryView';
 import LeafCategoryDetailView from '../views/leafCategoryDetails/LeafCategoryDetailView';
 import NotificationView from '../views/notifications/NotificationView';
+import MentalSupportView from '../views/mentalSupports/MentalSupportView';
 
 const Stack = createNativeStackNavigator();
 
@@ -45,6 +46,13 @@ const HomeStackNavigator = () => {
         <Stack.Screen
           name="NotificationView"
           component={NotificationView}
+          options={{
+            header: () => null,
+          }}
+        />
+        <Stack.Screen
+          name="MentalSupportView"
+          component={MentalSupportView}
           options={{
             header: () => null,
           }}

--- a/app/services/category_visit_service.js
+++ b/app/services/category_visit_service.js
@@ -2,6 +2,7 @@ import visitService from './visit_service';
 import categoryHelper from '../helpers/category_helper';
 import {tabVisitParams} from '../constants/bottom_tab_constant';
 import {navigationRef} from '../navigators/app_navigator';
+import {pageable_types} from '../constants/visit_constant';
 
 const categoryVisitService = (() => {
   return {
@@ -15,6 +16,10 @@ const categoryVisitService = (() => {
     }
     else if (categoryHelper.isClinicService(category))
       return visitService.recordVisitAction(tabVisitParams.service);
+    else if (categoryHelper.isMentalSupport(category)) {
+      visitService.recordVisitAction({code: "mental_support", name: "សេវាគាំទ្រផ្លូវចិត្ត", parent_code: null, pageable_id: null, pageable_type: pageable_types.page})
+      return navigationRef.current?.navigate("MentalSupportView", {name: category.name});
+    }
 
     visitService.recordVisitCategory(category)
   }

--- a/app/services/visit_service.js
+++ b/app/services/visit_service.js
@@ -6,6 +6,7 @@ import User from '../models/User';
 import networkService from './network_service';
 import VisitApi from '../api/visitApi';
 import {pageable_types} from '../constants/visit_constant';
+import {navigationRef} from '../navigators/app_navigator';
 
 const visitService = (() => {
   return {
@@ -18,7 +19,12 @@ const visitService = (() => {
 
   function recordVisitCategory(category) {
     category.pageable_type = pageable_types.page;
-    recordVisitAction(category, () => navigationService.navigateCategory(category.uuid));
+    recordVisitAction(category, () => {
+      if (category.code.includes("mental_support"))
+        return navigationRef.current?.navigate("MentalSupportView");
+
+      navigationService.navigateCategory(category.uuid)
+    });
   }
 
   function recordVisitVideo(video, callback) {

--- a/app/services/visit_service.js
+++ b/app/services/visit_service.js
@@ -6,8 +6,6 @@ import User from '../models/User';
 import networkService from './network_service';
 import VisitApi from '../api/visitApi';
 import {pageable_types} from '../constants/visit_constant';
-import {navigationRef} from '../navigators/app_navigator';
-import categoryHelper from '../helpers/category_helper';
 
 const visitService = (() => {
   return {
@@ -21,9 +19,6 @@ const visitService = (() => {
   function recordVisitCategory(category) {
     category.pageable_type = pageable_types.page;
     recordVisitAction(category, () => {
-      if (categoryHelper.isMentalSupport(category))
-        return navigationRef.current?.navigate("MentalSupportView", {name: category.name});
-
       navigationService.navigateCategory(category.uuid)
     });
   }

--- a/app/services/visit_service.js
+++ b/app/services/visit_service.js
@@ -7,6 +7,7 @@ import networkService from './network_service';
 import VisitApi from '../api/visitApi';
 import {pageable_types} from '../constants/visit_constant';
 import {navigationRef} from '../navigators/app_navigator';
+import categoryHelper from '../helpers/category_helper';
 
 const visitService = (() => {
   return {
@@ -20,8 +21,8 @@ const visitService = (() => {
   function recordVisitCategory(category) {
     category.pageable_type = pageable_types.page;
     recordVisitAction(category, () => {
-      if (category.code.includes("mental_support"))
-        return navigationRef.current?.navigate("MentalSupportView");
+      if (categoryHelper.isMentalSupport(category))
+        return navigationRef.current?.navigate("MentalSupportView", {name: category.name});
 
       navigationService.navigateCategory(category.uuid)
     });

--- a/app/themes/color.js
+++ b/app/themes/color.js
@@ -20,7 +20,8 @@ const color = {
   requiredColor: '#d50000',
   bigButtonColor: '#ffffff',
   facebookColor: '#4267b2',
-  telegramColor: '#0088cc',
+  telegramColor: '#229ED9',
+  whatsappColor: '#4FCE5D',
 }
 
 export default color;

--- a/app/views/mentalSupports/MentalSupportView.android.js
+++ b/app/views/mentalSupports/MentalSupportView.android.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import NavigationHeaderWithBackButtonComponent from '../../components/shared/NavigationHeaderWithBackButtonComponent';
+import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
+import MentalSupportCardListComponent from '../../components/mentalSupports/MentalSupportCardListComponent';
+
+const MentalSupportView = () => {
+  return (
+    <GradientScrollViewComponent
+      header={<NavigationHeaderWithBackButtonComponent label={"សេវាគាំទ្រផ្លូចិត្ត"} />}
+      body={<MentalSupportCardListComponent />}
+    />
+  )
+}
+
+export default MentalSupportView;

--- a/app/views/mentalSupports/MentalSupportView.android.js
+++ b/app/views/mentalSupports/MentalSupportView.android.js
@@ -4,10 +4,10 @@ import NavigationHeaderWithBackButtonComponent from '../../components/shared/Nav
 import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
 import MentalSupportCardListComponent from '../../components/mentalSupports/MentalSupportCardListComponent';
 
-const MentalSupportView = () => {
+const MentalSupportView = (props) => {
   return (
     <GradientScrollViewComponent
-      header={<NavigationHeaderWithBackButtonComponent label={"សេវាគាំទ្រផ្លូចិត្ត"} />}
+      header={<NavigationHeaderWithBackButtonComponent label={props.route.params.name} />}
       body={<MentalSupportCardListComponent />}
     />
   )


### PR DESCRIPTION
This pull request is creating the Mental Support Service page.
When the user pressed the contact card item, it will record the visit action with the below label:
- Phone label is: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280) - phone"
- SMS label is: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280) - sms"
- Messenger label is: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280) - messenger"
- Telegram label is: "បណ្ដាញទូរស័ទ្ទជំនួយកុមារកម្ពុជា(1280) - telegram"

Below are the updated screenshots on mobile and tablet devices:
[updated mental support service.zip](https://github.com/kawsangs/adolescents_app/files/9994362/updated.mental.support.service.zip)

