### PR TITLE
Lock app in portrait mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize"
+        android:screenOrientation="nosensor"
         android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />

--- a/app/components/loginSelections/LoginSelectionButtonsComponent.android.js
+++ b/app/components/loginSelections/LoginSelectionButtonsComponent.android.js
@@ -5,8 +5,6 @@ import LoginSelectionButtonComponent from './LoginSelectionButtonComponent';
 import LoginSelectionLineComponent from './LoginSelectionLineComponent';
 import {navigationRef} from '../../navigators/app_navigator';
 import appUserService from '../../services/app_user_service';
-import safetyPlan from '../../assets/audios/safety_plan.mp3';
-import yourStory from '../../assets/audios/your_story.mp3';
 
 const LoginSelectionButtonsComponent = () => {
   const {t} = useTranslation();
@@ -24,7 +22,7 @@ const LoginSelectionButtonsComponent = () => {
         label={t('useWithPersonalInfo')}
         iconName="user"
         btnStyle={{marginTop: 18}}
-        audio={safetyPlan}
+        audio={null}
         isAnonymous={false}
         playingUuid={playingUuid}
         updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
@@ -34,7 +32,7 @@ const LoginSelectionButtonsComponent = () => {
       <LoginSelectionButtonComponent
         uuid='2'
         label={t('useWithoutPersonalInfo')}
-        audio={yourStory}
+        audio={null}
         isAnonymous={true}
         playingUuid={playingUuid}
         updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}

--- a/app/views/playVideos/PlayVideoView.js
+++ b/app/views/playVideos/PlayVideoView.js
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {View} from 'react-native';
 import YoutubePlayer from "react-native-youtube-iframe";
+import { heightPercentageToDP as hp } from 'react-native-responsive-screen';
 
 import PlayVideoHeaderComponent from '../../components/playVideos/PlayVideoHeaderComponent';
 import PlayVideoWarningMessageComponent from '../../components/playVideos/PlayVideoWarningMessageComponent';
@@ -26,7 +27,7 @@ const PlayVideoView = (props) => {
 
     return <View style={{flex: 1, justifyContent: 'center'}}>
               <YoutubePlayer
-                height={300}
+                height={hp("37%")}
                 play={true}
                 videoId={youtubeHelper.getVideoId(video.url)}
               />


### PR DESCRIPTION
This pull request is locking the app in portrait mode and making some enhancements:
- Update the height of the video to make it responsive with different device type
- Remove the audio from the login options screen

** NOTE: The title of the play video screen will hide when the video is showing in full-screen mode on both landscape view and portrait view.