### PR TITLE
Fix the style of the category detail screen for iOS devices

### DIFF
--- a/app/components/shared/ScrollViewWithAudioComponent.android.js
+++ b/app/components/shared/ScrollViewWithAudioComponent.android.js
@@ -5,7 +5,7 @@ import BoldLabelComponent from './BoldLabelComponent';
 import ScrollViewHeaderComponent from './scrollViewWithAudios/ScrollViewHeaderComponent';
 import HtmlDescriptionComponent from './HtmlDescriptionComponent';
 import color from '../../themes/color';
-import { headerWithAudioMaxHeight, scrollViewPaddingBottom, descriptionLineHeight } from '../../constants/component_constant';
+import { androidHeaderWithAudioMaxHeight, scrollViewPaddingBottom, descriptionLineHeight } from '../../constants/component_constant';
 
 const ScrollViewWithAudioComponent = (props) => {
   const scrollY = new Animated.Value(0);
@@ -14,7 +14,7 @@ const ScrollViewWithAudioComponent = (props) => {
   const renderContent = () => {
     return (
       <View style={styles.scrollViewContent}>
-        <BoldLabelComponent label={props.title} style={{color: color.blackColor, fontSize: parseFloat(textSize) + 2, marginTop: 14, lineHeight: 30}} />
+        <BoldLabelComponent label={props.title} style={{color: color.blackColor, fontSize: parseFloat(textSize) + 2, marginTop: 14, lineHeight: 30, marginBottom: 10}} />
         <HtmlDescriptionComponent source={props.description} textSize={textSize} />
       </View>
     )
@@ -35,7 +35,7 @@ const ScrollViewWithAudioComponent = (props) => {
 const styles = StyleSheet.create({
   scrollViewContent: {
     backgroundColor: color.whiteColor,
-    marginTop: headerWithAudioMaxHeight,
+    marginTop: androidHeaderWithAudioMaxHeight,
     paddingHorizontal: 24,
     paddingBottom: scrollViewPaddingBottom,
   }

--- a/app/components/shared/ScrollViewWithAudioComponent.ios.js
+++ b/app/components/shared/ScrollViewWithAudioComponent.ios.js
@@ -1,29 +1,28 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { Animated, View, ScrollView, StyleSheet } from 'react-native';
-import {Text} from 'react-native-paper';
 
 import BoldLabelComponent from './BoldLabelComponent';
 import ScrollViewHeaderComponent from './scrollViewWithAudios/ScrollViewHeaderComponent';
+import HtmlDescriptionComponent from './HtmlDescriptionComponent';
 import color from '../../themes/color';
-import { headerWithAudioMaxHeight, scrollViewPaddingBottom, descriptionLineHeight } from '../../constants/component_constant';
-import {xxLargeFontSize, descriptionFontSize} from '../../utils/font_size_util';
+import { iOSHeaderWithAudioMaxHeight, scrollViewPaddingBottom, descriptionLineHeight } from '../../constants/component_constant';
 
 const ScrollViewWithAudioComponent = (props) => {
   const scrollY = new Animated.Value(0);
+  const [textSize, setTextSize] = useState(props.defaultTextSize);
+
   const renderContent = () => {
     return (
       <View style={styles.scrollViewContent}>
-        <BoldLabelComponent label={props.title} style={{color: color.blackColor, fontSize: xxLargeFontSize(), marginTop: 14, lineHeight: 30}} />
-        <Text style={{fontSize: descriptionFontSize(), marginTop: 16, color: color.blackColor, lineHeight: descriptionLineHeight}}>
-          {props.description}
-        </Text>
+        <BoldLabelComponent label={props.title} style={{color: color.blackColor, fontSize: parseFloat(textSize) + 2, marginTop: 14, lineHeight: 30, marginBottom: 10}} />
+        <HtmlDescriptionComponent source={props.description} textSize={textSize} />
       </View>
     )
   }
 
   return (
     <View style={{flexGrow: 1}}>
-      <ScrollViewHeaderComponent title={props.title} image={props.image} audio={props.audio} scrollY={scrollY} />
+      <ScrollViewHeaderComponent title={props.title} image={props.image} audio={props.audio} uuid={props.uuid} scrollY={scrollY} textSize={textSize} updateTextSize={(textSize) => setTextSize(textSize)} />
       <ScrollView style={{flexGrow: 1, backgroundColor: color.whiteColor}} scrollEventThrottle={16}
         onScroll={Animated.event([{nativeEvent: {contentOffset: {y: scrollY}}}], { useNativeDriver: false })}
       >
@@ -35,8 +34,8 @@ const ScrollViewWithAudioComponent = (props) => {
 
 const styles = StyleSheet.create({
   scrollViewContent: {
-    backgroundColor: color.whiteSmokeColor,
-    marginTop: headerWithAudioMaxHeight,
+    backgroundColor: color.whiteColor,
+    marginTop: iOSHeaderWithAudioMaxHeight,
     paddingHorizontal: 24,
     paddingBottom: scrollViewPaddingBottom,
   }

--- a/app/components/shared/scrollViewWithAudios/AudioDurationLabelComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/AudioDurationLabelComponent.android.js
@@ -6,12 +6,12 @@ import color from '../../../themes/color';
 import audioUtil from '../../../utils/audio_util';
 import {mediumFontSize} from '../../../utils/font_size_util';
 import translationHelper from '../../../helpers/translation_helper';
-import { screenHorizontalPadding, headerWithAudioScrollDistance } from '../../../constants/component_constant';
+import { screenHorizontalPadding, androidHeaderWithAudioScrollDistance } from '../../../constants/component_constant';
 
 const AudioDurationLabelComponent = (props) => {
   const {i18n} = useTranslation();
   const labelPositionY = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, androidHeaderWithAudioScrollDistance],
     outputRange: [0, 6],
     extrapolate: 'clamp'
   });

--- a/app/components/shared/scrollViewWithAudios/AudioDurationLabelComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/AudioDurationLabelComponent.ios.js
@@ -6,12 +6,12 @@ import color from '../../../themes/color';
 import audioUtil from '../../../utils/audio_util';
 import {mediumFontSize} from '../../../utils/font_size_util';
 import translationHelper from '../../../helpers/translation_helper';
-import { screenHorizontalPadding, headerWithAudioScrollDistance } from '../../../constants/component_constant';
+import { screenHorizontalPadding, iOSHeaderWithAudioScrollDistance } from '../../../constants/component_constant';
 
 const AudioDurationLabelComponent = (props) => {
   const {i18n} = useTranslation();
   const labelPositionY = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, iOSHeaderWithAudioScrollDistance],
     outputRange: [0, 6],
     extrapolate: 'clamp'
   });

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.android.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Animated, View, StyleSheet } from 'react-native';
 
 import AudioControlButton from './AudioControlButton';
-import { headerWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
+import { androidHeaderWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
 import { FAST_FORWARD, REVERSE } from '../../../constants/audio_constant';
 import { getStyleOfDevice } from '../../../utils/responsive_util';
 import audioPlayerService from '../../../services/audio_player_service';
@@ -10,13 +10,13 @@ import audioPlayerService from '../../../services/audio_player_service';
 const HeaderAudioControlButtonsComponent = (props) => {
   // Scale for making the audio controls smaller or bigger when scrolling
   const audioControlScale = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, androidHeaderWithAudioScrollDistance],
     outputRange: [1, 0.75],
     extrapolate: 'clamp',
   });
 
   const audioControlPositionY = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, androidHeaderWithAudioScrollDistance],
     outputRange: getStyleOfDevice([80, 15], [70, 20]),
     extrapolate: 'clamp'
   });

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.ios.js
@@ -2,21 +2,21 @@ import React from 'react';
 import { Animated, View, StyleSheet } from 'react-native';
 
 import AudioControlButton from './AudioControlButton';
-import { headerWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
+import { iOSHeaderWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
 import { FAST_FORWARD, REVERSE } from '../../../constants/audio_constant';
-import { getStyleOfDevice } from '../../../utils/responsive_util';
+import { getStyleOfDevice, isLowPixelDensityDevice } from '../../../utils/responsive_util';
 import audioPlayerService from '../../../services/audio_player_service';
 
 const HeaderAudioControlButtonsComponent = (props) => {
   // Scale for making the audio controls smaller or bigger when scrolling
   const audioControlScale = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, iOSHeaderWithAudioScrollDistance],
     outputRange: [1, 0.75],
     extrapolate: 'clamp',
   });
 
   const audioControlPositionY = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, iOSHeaderWithAudioScrollDistance],
     outputRange: getStyleOfDevice([80, 15], [70, 20]),
     extrapolate: 'clamp'
   });
@@ -35,7 +35,7 @@ const HeaderAudioControlButtonsComponent = (props) => {
     });
   }
 
-  const forwardBackwardSize = getStyleOfDevice(34, 32);
+  const forwardBackwardSize = getStyleOfDevice(34, isLowPixelDensityDevice() ? 30 : 32);
 
   return (
     <View style={{flex: 1, paddingHorizontal: screenHorizontalPadding}}>
@@ -45,7 +45,7 @@ const HeaderAudioControlButtonsComponent = (props) => {
         <AudioControlButton iconName='play-back' size={forwardBackwardSize}
           onPress={() => audioPlayerService.fastForwardOrReverse(props.audioPlayer, REVERSE)}
         />
-        <AudioControlButton iconName={!!props.countInterval ? 'pause' : 'play'} size={getStyleOfDevice(55, 50)} onPress={() => playAudio()} />
+        <AudioControlButton iconName={!!props.countInterval ? 'pause' : 'play'} size={getStyleOfDevice(55, isLowPixelDensityDevice() ? 45 : 50)} onPress={() => playAudio()} />
         <AudioControlButton iconName='play-forward' size={forwardBackwardSize}
           onPress={() => audioPlayerService.fastForwardOrReverse(props.audioPlayer, FAST_FORWARD)}
         />
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
   audioControl: {
     flexDirection: 'row',
     justifyContent: 'center',
+    marginTop: getStyleOfDevice(14, 0)
   }
 });
 

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlComponent.ios.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 
 import HeaderAudioControlButtonsComponent from './HeaderAudioControlButtonsComponent';
 import AudioDurationLabelComponent from './AudioDurationLabelComponent';
@@ -10,7 +11,19 @@ const HeaderAudioControlComponent = (props) => {
     playSeconds: 0,
     duration: 0,
     countInterval: null,
-  })
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        if (!!state.audioPlayer && !!state.countInterval) {
+          state.audioPlayer.release();
+          clearInterval(state.countInterval);
+          setState({ audioPlayer: null, playSeconds: 0, duration: 0, countInterval: null });
+        }
+      }
+    }, [state.audioPlayer])
+  );
 
   const updateState = (audioPlayer, playSeconds, duration, countInterval) => {
     setState({ audioPlayer, playSeconds, duration, countInterval })
@@ -18,7 +31,7 @@ const HeaderAudioControlComponent = (props) => {
 
   return (
     <React.Fragment>
-      <HeaderAudioControlButtonsComponent audio={props.audio} scrollY={props.scrollY}
+      <HeaderAudioControlButtonsComponent uuid={props.uuid} audio={props.audio} scrollY={props.scrollY}
         audioPlayer={state.audioPlayer} countInterval={state.countInterval}
         updateAudioPlayer={updateState}
       />

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.android.js
@@ -4,12 +4,12 @@ import {Slider} from '@miblanchard/react-native-slider';
 
 import color from '../../../themes/color';
 import componentUtil from '../../../utils/component_util';
-import { headerWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
+import { androidHeaderWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
 import audioPlayerService from '../../../services/audio_player_service';
 
 const HeaderAudioSliderComponent = (props) => {
   const thumbSize = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, androidHeaderWithAudioScrollDistance],
     outputRange: [20, 16],
     extrapolate: 'clamp',
   });

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.ios.js
@@ -4,12 +4,12 @@ import {Slider} from '@miblanchard/react-native-slider';
 
 import color from '../../../themes/color';
 import componentUtil from '../../../utils/component_util';
-import { headerWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
+import { iOSHeaderWithAudioScrollDistance, screenHorizontalPadding } from '../../../constants/component_constant';
 import audioPlayerService from '../../../services/audio_player_service';
 
 const HeaderAudioSliderComponent = (props) => {
   const thumbSize = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, iOSHeaderWithAudioScrollDistance],
     outputRange: [20, 16],
     extrapolate: 'clamp',
   });
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
   sliderContainer: {
     paddingHorizontal: screenHorizontalPadding,
     height: 13,
-    backgroundColor: color.whiteSmokeColor,
+    backgroundColor: color.whiteColor,
     marginTop: 16
   }
 });

--- a/app/components/shared/scrollViewWithAudios/ScrollViewHeaderComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/ScrollViewHeaderComponent.android.js
@@ -5,18 +5,18 @@ import LinearGradient from 'react-native-linear-gradient';
 import color, {backgroundColors} from '../../../themes/color';
 import HeaderAudioControlComponent from './HeaderAudioControlComponent';
 import ScrollViewHeaderNavigationComponent from './ScrollViewHeaderNavigationComponent';
-import { headerWithAudioMaxHeight, headerWithAudioMinHeight, headerWithAudioScrollDistance } from '../../../constants/component_constant';
+import { androidHeaderWithAudioMaxHeight, androidHeaderWithAudioMinHeight, androidHeaderWithAudioScrollDistance } from '../../../constants/component_constant';
 import {getStyleOfDevice} from '../../../utils/responsive_util';
 
 const ScrollViewHeaderComponent = (props) => {
   const headerHeight = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
-    outputRange: [headerWithAudioMaxHeight, headerWithAudioMinHeight],
+    inputRange: [0, androidHeaderWithAudioScrollDistance],
+    outputRange: [androidHeaderWithAudioMaxHeight, androidHeaderWithAudioMinHeight],
     extrapolate: 'clamp',
   });
 
   const imageOpacity = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, androidHeaderWithAudioScrollDistance],
     outputRange: [1, 0],
     extrapolate: 'extend'
   });

--- a/app/components/shared/scrollViewWithAudios/ScrollViewHeaderComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/ScrollViewHeaderComponent.ios.js
@@ -1,22 +1,23 @@
 import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
+import DeviceInfo from 'react-native-device-info';
 
 import color, {backgroundColors} from '../../../themes/color';
 import HeaderAudioControlComponent from './HeaderAudioControlComponent';
 import ScrollViewHeaderNavigationComponent from './ScrollViewHeaderNavigationComponent';
-import { headerWithAudioMaxHeight, headerWithAudioMinHeight, headerWithAudioScrollDistance } from '../../../constants/component_constant';
+import { iOSHeaderWithAudioMaxHeight, iOSHeaderWithAudioMinHeight, iOSHeaderWithAudioScrollDistance } from '../../../constants/component_constant';
 import {getStyleOfDevice} from '../../../utils/responsive_util';
 
 const ScrollViewHeaderComponent = (props) => {
   const headerHeight = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
-    outputRange: [headerWithAudioMaxHeight, headerWithAudioMinHeight],
+    inputRange: [0, iOSHeaderWithAudioScrollDistance],
+    outputRange: [iOSHeaderWithAudioMaxHeight, iOSHeaderWithAudioMinHeight],
     extrapolate: 'clamp',
   });
 
   const imageOpacity = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, iOSHeaderWithAudioScrollDistance],
     outputRange: [1, 0],
     extrapolate: 'extend'
   });
@@ -31,10 +32,10 @@ const ScrollViewHeaderComponent = (props) => {
         <Animated.Image
           source={props.image}
           style={[styles.headerImage, {opacity: imageOpacity}]}
-          resizeMode="cover"
+          resizeMode="contain"
         />
-        <ScrollViewHeaderNavigationComponent scrollY={props.scrollY} title={props.title} />
-        <HeaderAudioControlComponent scrollY={props.scrollY} />
+        <ScrollViewHeaderNavigationComponent scrollY={props.scrollY} title={props.title} textSize={props.textSize} updateTextSize={props.updateTextSize} />
+        <HeaderAudioControlComponent uuid={props.uuid} audio={props.audio} scrollY={props.scrollY} />
       </LinearGradient>
     </Animated.View>
   )
@@ -51,9 +52,10 @@ const styles = StyleSheet.create({
     zIndex: 1
   },
   headerImage: {
-    height: getStyleOfDevice(110, 100),
+    height: getStyleOfDevice(130, 100),
     width: '100%',
-    position: 'absolute', top: 0,
+    position: 'absolute',
+    top: DeviceInfo.hasNotch() ? 46 : 26,
   }
 });
 

--- a/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.android.js
@@ -7,12 +7,12 @@ import NavigationHeaderBackButtonComponent from '../NavigationHeaderBackButtonCo
 import NavigationHeaderButtonComponent from '../navigationHeaders/NavigationHeaderButtonComponent';
 import NavigationHeaderTitleComponent from '../navigationHeaders/NavigationHeaderTitleComponent';
 import FontSizeSettingModalComponent from '../FontSizeSettingModalComponent';
-import {headerWithAudioScrollDistance, navigationHeaderIconSize} from '../../../constants/component_constant';
+import {androidHeaderWithAudioScrollDistance, navigationHeaderIconSize} from '../../../constants/component_constant';
 
 const ScrollViewHeaderNavigationComponent = (props) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const titleOpacity = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, androidHeaderWithAudioScrollDistance],
     outputRange: [0, 1],
     extrapolate: 'extend'
   });

--- a/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.ios.js
@@ -1,17 +1,27 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import { Appbar } from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 import NavigationHeaderBackButtonComponent from '../NavigationHeaderBackButtonComponent';
+import NavigationHeaderButtonComponent from '../navigationHeaders/NavigationHeaderButtonComponent';
 import NavigationHeaderTitleComponent from '../navigationHeaders/NavigationHeaderTitleComponent';
-import {headerWithAudioScrollDistance} from '../../../constants/component_constant';
+import FontSizeSettingModalComponent from '../FontSizeSettingModalComponent';
+import {iOSHeaderWithAudioScrollDistance, navigationHeaderIconSize} from '../../../constants/component_constant';
 
 const ScrollViewHeaderNavigationComponent = (props) => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
   const titleOpacity = props.scrollY.interpolate({
-    inputRange: [0, headerWithAudioScrollDistance],
+    inputRange: [0, iOSHeaderWithAudioScrollDistance],
     outputRange: [0, 1],
     extrapolate: 'extend'
   });
+
+  const renderFontSettingButton = () => {
+    return <NavigationHeaderButtonComponent onPress={() => setIsModalVisible(true)}
+            icon={<Icon name="format-size" size={navigationHeaderIconSize} color={'white'} />}
+          />
+  }
 
   return (
     <Appbar.Header style={styles.container}>
@@ -19,6 +29,9 @@ const ScrollViewHeaderNavigationComponent = (props) => {
       <Animated.View style={{flex: 1, paddingLeft: 8, opacity: titleOpacity}}>
         <NavigationHeaderTitleComponent label={props.title} />
       </Animated.View>
+      {renderFontSettingButton()}
+
+      <FontSizeSettingModalComponent visible={isModalVisible} onDismiss={() => setIsModalVisible(false)} textSize={props.textSize} updateTextSize={props.updateTextSize} />
     </Appbar.Header>
   )
 }

--- a/app/constants/component_constant.js
+++ b/app/constants/component_constant.js
@@ -1,4 +1,5 @@
 import {Platform} from 'react-native';
+import DeviceInfo from 'react-native-device-info';
 import { getStyleOfDevice, isLowPixelDensityDevice } from '../utils/responsive_util';
 import {xLargeFontSize, largeFontSize} from '../utils/font_size_util';
 
@@ -6,9 +7,14 @@ export const buttonBorderRadius = 10;
 export const cardElevation = 2;
 export const cardBorderRadius = 10;
 export const outlinedButtonBorderWidth = 2.2;
-export const headerWithAudioMaxHeight = getStyleOfDevice(265, 230);
-export const headerWithAudioMinHeight = 170;
-export const headerWithAudioScrollDistance = (headerWithAudioMaxHeight - headerWithAudioMinHeight);
+export const androidHeaderWithAudioMaxHeight = getStyleOfDevice(265, 230);
+export const androidHeaderWithAudioMinHeight = 170;
+export const androidHeaderWithAudioScrollDistance = (androidHeaderWithAudioMaxHeight - androidHeaderWithAudioMinHeight);
+const iOSMobileMaxHeight = DeviceInfo.hasNotch() ? 270 : 250;
+const iOSMobileMinHeight = DeviceInfo.hasNotch() ? 200 : 180;
+export const iOSHeaderWithAudioMaxHeight = getStyleOfDevice(285, iOSMobileMaxHeight);
+export const iOSHeaderWithAudioMinHeight = getStyleOfDevice(220, iOSMobileMinHeight);
+export const iOSHeaderWithAudioScrollDistance = (iOSHeaderWithAudioMaxHeight - iOSHeaderWithAudioMinHeight);
 export const navigationHeaderIconSize = 24;
 export const navigationHeaderHorizontalPadding = getStyleOfDevice(16, 6);
 export const navigationHeaderHeight = Platform.OS == 'ios' ? 56 : 56;

--- a/app/views/leafCategoryDetails/LeafCategoryDetailView.ios.js
+++ b/app/views/leafCategoryDetails/LeafCategoryDetailView.ios.js
@@ -7,10 +7,12 @@ const LeafCategoryDetailView = ({route, navigation}) => {
 
   return (
     <ScrollViewWithAudioComponent
+      uuid={route.params.uuid}
       title={category.name}
       description={category.description}
       audio={category.audioSource}
       image={category.imageSource}
+      defaultTextSize={route.params.textSize}
     />
   )
 }


### PR DESCRIPTION
This pull request is fixing the style of the category detail screen for iOS devices.

Below are the screenshots on the mobile and tablet devices:
[category detail iOS.zip](https://github.com/kawsangs/adolescents_app/files/10064947/category.detail.iOS.zip)
