### PR TITLE
Fix topic detail style on iphone 14

### DIFF
--- a/app/components/facilityDetails/FacilityDetailGalleryComponent.ios.js
+++ b/app/components/facilityDetails/FacilityDetailGalleryComponent.ios.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, Image, StyleSheet} from 'react-native';
 import Swiper from 'react-native-swiper'
+import DeviceInfo from 'react-native-device-info';
 
 import EmptyImageComponent from '../shared/EmptyImageComponent';
 import color from '../../themes/color';
@@ -25,7 +26,7 @@ const FacilityDetailGalleryComponent = (props) => {
   }
 
   return (
-    <View style={{height: galleries.length > 0 ? getStyleOfDevice(260, 216) : getStyleOfDevice(260, 180)}}>
+    <View style={{height: galleries.length > 0 ? getStyleOfDevice(260, DeviceInfo.hasDynamicIsland() ? 256 : 216) : getStyleOfDevice(260, DeviceInfo.hasDynamicIsland() ? 220 : 180)}}>
       { galleries.length > 0 ? renderImageSlider()
         : <EmptyImageComponent iconSize={getStyleOfDevice(32, 40)} labelStyle={{fontSize: 12}} iconContainerStyle={styles.emptyIconContainer} />
       }

--- a/app/constants/ios_component_constant.js
+++ b/app/constants/ios_component_constant.js
@@ -2,7 +2,7 @@ import DeviceInfo from 'react-native-device-info';
 import { getStyleOfDevice } from '../utils/responsive_util';
 
 export const iPhoneStatusBarHeight = 26;
-export const iPhoneNotchHeight = 46;
+export const iPhoneNotchHeight = DeviceInfo.hasDynamicIsland() ? 59 : 46;
 
 const mobileMaxHeight = DeviceInfo.hasNotch() ? 270 : 250;
 const mobileMinHeight = DeviceInfo.hasNotch() ? 200 : 180;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-i18next": "^11.18.3",
         "react-native": "0.70.3",
         "react-native-app-intro-slider": "^4.0.4",
-        "react-native-device-info": "^10.0.2",
+        "react-native-device-info": "^10.3.0",
         "react-native-encrypted-storage": "^4.0.2",
         "react-native-gesture-handler": "^2.6.0",
         "react-native-linear-gradient": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-i18next": "^11.18.3",
     "react-native": "0.70.3",
     "react-native-app-intro-slider": "^4.0.4",
-    "react-native-device-info": "^10.0.2",
+    "react-native-device-info": "^10.3.0",
     "react-native-encrypted-storage": "^4.0.2",
     "react-native-gesture-handler": "^2.6.0",
     "react-native-linear-gradient": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6725,7 +6725,7 @@
     "jscodeshift" "^0.13.1"
     "nullthrows" "^1.1.1"
 
-"react-native-device-info@^10.0.2":
+"react-native-device-info@^10.3.0":
   "integrity" "sha512-/ziZN1sA1REbJTv5mQZ4tXggcTvSbct+u5kCaze8BmN//lbxcTvWsU6NQd4IihLt89VkbX+14IGc9sVApSxd/w=="
   "resolved" "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-10.3.0.tgz"
   "version" "10.3.0"


### PR DESCRIPTION
This pull request is fixing the style of the navigation header on the category detail, facility detail, and topic detail screen on iPhone 14 pro and 14 pro max (with dynamic island).

NOTE: this pull request is updating the version of the react-native-device-info from 10.0.2 to 10.3.0 in order to be able to detect the dynamic island of the device. (https://github.com/react-native-device-info/react-native-device-info)

Below are the screenshots of the screens before and after the fix:
[Fix dynamic island.zip](https://github.com/kawsangs/adolescents_app/files/10182192/Fix.dynamic.island.zip)
