### PR TITLE
Update the touch target size of the audio button in category detail s…

### DIFF
--- a/app/components/shared/scrollViewWithAudios/AudioControlButton.android.js
+++ b/app/components/shared/scrollViewWithAudios/AudioControlButton.android.js
@@ -14,8 +14,8 @@ const AudioControlButton = (props) => {
 
 const styles = StyleSheet.create({
   button: {
-    minWidth: componentUtil.pressableItemSize(),
-    minHeight: componentUtil.pressableItemSize(),
+    minWidth: componentUtil.largePressableItemSize(),
+    minHeight: componentUtil.largePressableItemSize(),
     alignItems: 'center',
     justifyContent: 'center',
     marginHorizontal: componentUtil.pressableItemSize() - getStyleOfDevice(15, 20),

--- a/app/components/shared/scrollViewWithAudios/AudioControlButton.ios.js
+++ b/app/components/shared/scrollViewWithAudios/AudioControlButton.ios.js
@@ -14,8 +14,8 @@ const AudioControlButton = (props) => {
 
 const styles = StyleSheet.create({
   button: {
-    minWidth: componentUtil.pressableItemSize(),
-    minHeight: componentUtil.pressableItemSize(),
+    minWidth: componentUtil.largePressableItemSize(),
+    minHeight: componentUtil.largePressableItemSize(),
     alignItems: 'center',
     justifyContent: 'center',
     marginHorizontal: componentUtil.pressableItemSize() - getStyleOfDevice(15, 20),

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.android.js
@@ -12,7 +12,7 @@ const HeaderAudioControlButtonsComponent = (props) => {
   // Scale for making the audio controls smaller or bigger when scrolling
   const audioControlScale = props.scrollY.interpolate({
     inputRange: [0, headerWithAudioScrollDistance],
-    outputRange: [1, 0.75],
+    outputRange: [1, 0.80],
     extrapolate: 'clamp',
   });
 

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.ios.js
@@ -12,7 +12,7 @@ const HeaderAudioControlButtonsComponent = (props) => {
   // Scale for making the audio controls smaller or bigger when scrolling
   const audioControlScale = props.scrollY.interpolate({
     inputRange: [0, headerWithAudioScrollDistance],
-    outputRange: [1, 0.75],
+    outputRange: [1, 0.80],
     extrapolate: 'clamp',
   });
 

--- a/app/components/videos/VideoThumbnailComponent.ios.js
+++ b/app/components/videos/VideoThumbnailComponent.ios.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Image, TouchableOpacity, StyleSheet} from 'react-native';
+import {Image, TouchableOpacity, StyleSheet, View} from 'react-native';
 import FeatherIcon from 'react-native-vector-icons/Feather';
 
 import EmptyMediaComponent from '../shared/EmptyMediaComponent';
@@ -14,9 +14,9 @@ const HEIGHT = getStyleOfDevice(220, MOBILE_HEIGHT);
 
 const VideoThumbnailComponent = (props) => {
   const renderPlayButton = () => {
-    return <TouchableOpacity onPress={() => youtubeHelper.openVideo(props.url)} style={styles.playBtn}>
+    return <View style={styles.playBtn}>
               <FeatherIcon name="play" size={24} color={color.primaryColor} style={{marginLeft: 2}} />
-           </TouchableOpacity>
+           </View>
   }
 
   const renderThumbnail = () => {

--- a/app/utils/component_util.js
+++ b/app/utils/component_util.js
@@ -8,6 +8,7 @@ const componentUtil = (() => {
   return {
     pressableItemSize,
     mediumPressableItemSize,
+    largePressableItemSize,
     getGridCardWidth,
   }
 
@@ -17,6 +18,10 @@ const componentUtil = (() => {
 
   function mediumPressableItemSize() {
     return isLowPixelDensityDevice() ? pressableItemSize() : pressableItemSize(8);
+  }
+
+  function largePressableItemSize() {
+    return 60;
   }
 
   function getGridCardWidth() {


### PR DESCRIPTION
This pull request is updating the size of the audio buttons on the category detail screen to be >= 48dp (from the accessibility report from Google Play Console) when the user scrolls down and the screen header starts shrinking. 