### PR TITLE
Fix style home screen for tablet

### DIFF
--- a/app/assets/stylesheets/mobile/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/mobile/tiltedCardComponentStyles.js
@@ -23,6 +23,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
       ios: {
         borderBottomRightRadius: 40,
         top: isLowPixelDensityDevice() ? -5.5 : -7,
+        right: -2.9
       },
       android: {
         borderBottomRightRadius: 26,

--- a/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
@@ -1,13 +1,21 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import { cardBorderRadius } from '../../../constants/component_constant';
+import {getiPadStyle} from '../../../utils/responsive_util';
 
 const horizontalCardComponentStyles = StyleSheet.create({
   container: {
     borderRadius: cardBorderRadius,
-    height: 115,
     paddingLeft: 12,
     paddingRight: 4,
-    width: '100%'
+    width: '100%',
+    ...Platform.select({
+      ios: {
+        height: getiPadStyle(140, 140, 160),
+      },
+      android: {
+        height: 115,
+      }
+    })
   }
 });
 

--- a/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
@@ -1,6 +1,6 @@
 import { StyleSheet, Platform } from 'react-native';
 import { cardBorderRadius } from '../../../constants/component_constant';
-import {getiPadStyle} from '../../../utils/responsive_util';
+import {getiPadStyle, getAndroidTabletStyle} from '../../../utils/responsive_util';
 
 const horizontalCardComponentStyles = StyleSheet.create({
   container: {
@@ -13,7 +13,7 @@ const horizontalCardComponentStyles = StyleSheet.create({
         height: getiPadStyle(140, 140, 160),
       },
       android: {
-        height: 115,
+        height: getAndroidTabletStyle(115, 130),
       }
     })
   }

--- a/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import color from '../../../themes/color';
 import { smallFontSize } from '../../../utils/font_size_util';
 import {cardTitleFontSize} from '../../../constants/component_constant';
@@ -8,7 +8,14 @@ const horizontalCardInfoComponentStyles = StyleSheet.create({
     flex: 2,
     flexDirection: 'column',
     paddingLeft: 8,
-    paddingTop: 8,
+    ...Platform.select({
+      ios: {
+        paddingTop: 16
+      },
+      android: {
+        paddingTop: 8
+      }
+    })
   },
   titleContainer: {
     flex: 1,

--- a/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
@@ -2,6 +2,7 @@ import { StyleSheet, Platform } from 'react-native';
 import color from '../../../themes/color';
 import { smallFontSize } from '../../../utils/font_size_util';
 import {cardTitleFontSize} from '../../../constants/component_constant';
+import {getAndroidTabletStyle} from '../../../utils/responsive_util';
 
 const horizontalCardInfoComponentStyles = StyleSheet.create({
   container: {
@@ -13,7 +14,7 @@ const horizontalCardInfoComponentStyles = StyleSheet.create({
         paddingTop: 16
       },
       android: {
-        paddingTop: 8
+        paddingTop: getAndroidTabletStyle(8, 16)
       }
     })
   },

--- a/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
@@ -1,10 +1,8 @@
-import {StyleSheet, Platform} from 'react-native';
+import {StyleSheet, Platform, Dimensions} from 'react-native';
 import color from '../../../themes/color';
 import {cardTitleFontSize} from '../../../constants/component_constant';
 import componentUtil from '../../../utils/component_util';
-import {getiPadStyle} from '../../../utils/responsive_util';
-
-const iOSRotate = getiPadStyle("-8deg", "-7deg", "-5.5deg");
+import {getiPadStyle, getAndroidTabletStyle} from '../../../utils/responsive_util';
 
 const tiltedCardComponentStyles = StyleSheet.create({
   container: {
@@ -32,13 +30,13 @@ const tiltedCardComponentStyles = StyleSheet.create({
         borderBottomRightRadius: 65.8,
         right: -3,
         top: -23,
-        transform: [{rotate: iOSRotate}],
+        transform: [{rotate: getiPadStyle("-8deg", "-7deg", "-5.5deg")}],
       },
       android: {
         borderBottomRightRadius: 42,
-        right: -3.5,
+        right: getAndroidTabletStyle(-3.5, -2.5),
         top: -24,
-        transform: [{rotate: "-11deg"}],
+        transform: [{rotate: getAndroidTabletStyle("-11deg", "-8deg")}],
       }
     })
   },
@@ -53,7 +51,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
         top: getiPadStyle(-26, -26, -29)
       },
       android: {
-        right: 0.4,
+        right: getAndroidTabletStyle(0.4, 0),
         top: -24,
       }
     })

--- a/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
@@ -2,6 +2,9 @@ import {StyleSheet, Platform} from 'react-native';
 import color from '../../../themes/color';
 import {cardTitleFontSize} from '../../../constants/component_constant';
 import componentUtil from '../../../utils/component_util';
+import {getiPadStyle} from '../../../utils/responsive_util';
+
+const iOSRotate = getiPadStyle("-8deg", "-7deg", "-5.5deg");
 
 const tiltedCardComponentStyles = StyleSheet.create({
   container: {
@@ -20,7 +23,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
     backgroundColor: color.whiteColor,
     height: 60,
     width: componentUtil.getGridCardWidth() + 2,
-    borderTopRightRadius: 20,
+    borderTopRightRadius: getiPadStyle(20, 20, 12),
     borderTopLeftRadius: 14,
     position: 'absolute',
     borderColor: 'transparent',
@@ -29,7 +32,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
         borderBottomRightRadius: 65.8,
         right: -3,
         top: -23,
-        transform: [{rotate: "-8deg"}],
+        transform: [{rotate: iOSRotate}],
       },
       android: {
         borderBottomRightRadius: 42,
@@ -47,7 +50,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
     ...Platform.select({
       ios: {
         right: 0,
-        top: -26,
+        top: getiPadStyle(-26, -26, -29)
       },
       android: {
         right: 0.4,

--- a/app/constants/component_constant.js
+++ b/app/constants/component_constant.js
@@ -16,3 +16,4 @@ export const cardTitleFontSize = xLargeFontSize();
 export const descriptionFontSize = largeFontSize();
 export const descriptionLineHeight = getStyleOfDevice(38, isLowPixelDensityDevice() ? 28 : 36);
 export const navHeaderHeight = 56;
+export const androidBigTabletWidth = 800;

--- a/app/constants/ios_device_constant.js
+++ b/app/constants/ios_device_constant.js
@@ -1,0 +1,3 @@
+export const iPadMiniWidth = 744;
+export const iPadPro11Width = 834;
+export const iPadPro12Width = 1024;

--- a/app/utils/responsive_util.js
+++ b/app/utils/responsive_util.js
@@ -3,6 +3,7 @@ import DeviceInfo from 'react-native-device-info'
 
 import { smallMobileHeight, mediumMobileHeight, smallWidthMobile, XHDPIRatio } from '../constants/screen_size_constant';
 import {iPadPro11Width, iPadPro12Width} from '../constants/ios_device_constant';
+import {androidBigTabletWidth} from '../constants/component_constant';
 
 const screenHeight = Dimensions.get('screen').height;
 const screenWidth = Dimensions.get('screen').width;
@@ -37,6 +38,10 @@ export const getiPadStyle = (smallStyle, mediumStyle, largeStyle) => {
     return largeStyle;
 
   return Dimensions.get('window').width >= iPadPro11Width ? mediumStyle : smallStyle;
+}
+
+export const getAndroidTabletStyle = (smallStyle, mediumStyle) => {
+  return Dimensions.get('window').width >= androidBigTabletWidth ? mediumStyle : smallStyle;
 }
 
 export const isLowPixelDensityDevice = () => {

--- a/app/utils/responsive_util.js
+++ b/app/utils/responsive_util.js
@@ -2,6 +2,7 @@ import { Dimensions, PixelRatio } from 'react-native';
 import DeviceInfo from 'react-native-device-info'
 
 import { smallMobileHeight, mediumMobileHeight, smallWidthMobile, XHDPIRatio } from '../constants/screen_size_constant';
+import {iPadPro11Width, iPadPro12Width} from '../constants/ios_device_constant';
 
 const screenHeight = Dimensions.get('screen').height;
 const screenWidth = Dimensions.get('screen').width;
@@ -29,6 +30,13 @@ export const mobileIconSize = (size) => {
   }
 
   return size;
+}
+
+export const getiPadStyle = (smallStyle, mediumStyle, largeStyle) => {
+  if (Dimensions.get('window').width >= iPadPro12Width)
+    return largeStyle;
+
+  return Dimensions.get('window').width >= iPadPro11Width ? mediumStyle : smallStyle;
 }
 
 export const isLowPixelDensityDevice = () => {


### PR DESCRIPTION
This pull request is updating the style of the card items on the home screen for the iPads.

Below are the screenshots of the iPad mini, iPad pro 11 inches, iPad prop 12.9 inches, and 10 inches Android tablet:
[home screen on tablet.zip](https://github.com/kawsangs/adolescents_app/files/10244510/home.screen.on.tablet.zip)

