### PR TITLE
Fix style home screen for tablet

### DIFF
--- a/app/assets/stylesheets/mobile/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/mobile/tiltedCardComponentStyles.js
@@ -23,6 +23,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
       ios: {
         borderBottomRightRadius: 40,
         top: isLowPixelDensityDevice() ? -5.5 : -7,
+        right: -2.9
       },
       android: {
         borderBottomRightRadius: 26,

--- a/app/assets/stylesheets/tablet/bottomSheetPickerComponentStyles.js
+++ b/app/assets/stylesheets/tablet/bottomSheetPickerComponentStyles.js
@@ -9,7 +9,7 @@ const BottomSheetPickerComponentStyles = StyleSheet.create({
     backgroundColor: color.whiteColor,
     borderRadius: cardBorderRadius,
     marginTop: 5,
-    height: componentUtil.mediumPressableItemSize(),
+    height: componentUtil.tabletPressableItemSize(),
   },
   titleLabel: {
     color: color.whiteColor,

--- a/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
@@ -1,13 +1,21 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import { cardBorderRadius } from '../../../constants/component_constant';
+import {getiPadStyle} from '../../../utils/responsive_util';
 
 const horizontalCardComponentStyles = StyleSheet.create({
   container: {
     borderRadius: cardBorderRadius,
-    height: 115,
     paddingLeft: 12,
     paddingRight: 4,
-    width: '100%'
+    width: '100%',
+    ...Platform.select({
+      ios: {
+        height: getiPadStyle(140, 140, 160),
+      },
+      android: {
+        height: 115,
+      }
+    })
   }
 });
 

--- a/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardComponentStyles.js
@@ -1,6 +1,6 @@
 import { StyleSheet, Platform } from 'react-native';
 import { cardBorderRadius } from '../../../constants/component_constant';
-import {getiPadStyle} from '../../../utils/responsive_util';
+import {getiPadStyle, getAndroidTabletStyle} from '../../../utils/responsive_util';
 
 const horizontalCardComponentStyles = StyleSheet.create({
   container: {
@@ -13,7 +13,7 @@ const horizontalCardComponentStyles = StyleSheet.create({
         height: getiPadStyle(140, 140, 160),
       },
       android: {
-        height: 115,
+        height: getAndroidTabletStyle(115, 130),
       }
     })
   }

--- a/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import color from '../../../themes/color';
 import { smallFontSize } from '../../../utils/font_size_util';
 import {cardTitleFontSize} from '../../../constants/component_constant';
@@ -8,7 +8,14 @@ const horizontalCardInfoComponentStyles = StyleSheet.create({
     flex: 2,
     flexDirection: 'column',
     paddingLeft: 8,
-    paddingTop: 8,
+    ...Platform.select({
+      ios: {
+        paddingTop: 16
+      },
+      android: {
+        paddingTop: 8
+      }
+    })
   },
   titleContainer: {
     flex: 1,

--- a/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
+++ b/app/assets/stylesheets/tablet/horizontalCardInfoComponentStyles.js
@@ -2,6 +2,7 @@ import { StyleSheet, Platform } from 'react-native';
 import color from '../../../themes/color';
 import { smallFontSize } from '../../../utils/font_size_util';
 import {cardTitleFontSize} from '../../../constants/component_constant';
+import {getAndroidTabletStyle} from '../../../utils/responsive_util';
 
 const horizontalCardInfoComponentStyles = StyleSheet.create({
   container: {
@@ -13,7 +14,7 @@ const horizontalCardInfoComponentStyles = StyleSheet.create({
         paddingTop: 16
       },
       android: {
-        paddingTop: 8
+        paddingTop: getAndroidTabletStyle(8, 16)
       }
     })
   },

--- a/app/assets/stylesheets/tablet/loginSelectionButtonComponentStyles.js
+++ b/app/assets/stylesheets/tablet/loginSelectionButtonComponentStyles.js
@@ -12,7 +12,7 @@ const loginSelectionButtonComponentStyles = StyleSheet.create({
     backgroundColor: color.whiteColor,
     borderRadius: borderRadius,
     flexDirection: 'row',
-    height: componentUtil.mediumPressableItemSize(),
+    height: componentUtil.tabletPressableItemSize(),
     width: '100%'
   },
   leftIconContainer: {

--- a/app/assets/stylesheets/tablet/loginSelectionViewStyles.js
+++ b/app/assets/stylesheets/tablet/loginSelectionViewStyles.js
@@ -1,28 +1,44 @@
-import {StyleSheet} from 'react-native';
+import {StyleSheet, Platform} from 'react-native';
 import color from '../../../themes/color';
-import {largeFontSize} from '../../../utils/font_size_util';
+import {xxLargeFontSize} from '../../../utils/font_size_util';
 
 const loginSelectionViewStyles = StyleSheet.create({
   logo: {
     alignSelf: 'center',
-    width: 108,
-    height: 110,
+    ...Platform.select({
+      ios: {
+        width: 208,
+        height: 210,
+      },
+      android: {
+        width: 148,
+        height: 150,
+      }
+    })
   },
   title: {
     color: color.whiteColor,
-    fontSize: 26,
     marginTop: 16,
     textAlign: 'center',
     textShadowColor: '#000',
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 6,
-    paddingBottom: 2
+    paddingBottom: 2,
+    ...Platform.select({
+      ios: {
+        fontSize: 46,
+      },
+      android: {
+        fontSize: 36,
+        lineHeight: 45
+      }
+    })
   },
   label: {
     color: color.whiteColor,
     marginTop: 78,
     textAlign: 'center',
-    fontSize: largeFontSize()
+    fontSize: xxLargeFontSize()
   }
 });
 

--- a/app/assets/stylesheets/tablet/selectionItemComponentStyles.js
+++ b/app/assets/stylesheets/tablet/selectionItemComponentStyles.js
@@ -5,7 +5,7 @@ import componentUtil from '../../../utils/component_util';
 
 const selectionItemComponentStyles = StyleSheet.create({
   selectionItem: {
-    height: componentUtil.mediumPressableItemSize(),
+    height: componentUtil.tabletPressableItemSize(),
     paddingLeft: 8
   },
   label: {

--- a/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
@@ -1,10 +1,8 @@
-import {StyleSheet, Platform} from 'react-native';
+import {StyleSheet, Platform, Dimensions} from 'react-native';
 import color from '../../../themes/color';
 import {cardTitleFontSize} from '../../../constants/component_constant';
 import componentUtil from '../../../utils/component_util';
-import {getiPadStyle} from '../../../utils/responsive_util';
-
-const iOSRotate = getiPadStyle("-8deg", "-7deg", "-5.5deg");
+import {getiPadStyle, getAndroidTabletStyle} from '../../../utils/responsive_util';
 
 const tiltedCardComponentStyles = StyleSheet.create({
   container: {
@@ -32,13 +30,13 @@ const tiltedCardComponentStyles = StyleSheet.create({
         borderBottomRightRadius: 65.8,
         right: -3,
         top: -23,
-        transform: [{rotate: iOSRotate}],
+        transform: [{rotate: getiPadStyle("-8deg", "-7deg", "-5.5deg")}],
       },
       android: {
         borderBottomRightRadius: 42,
-        right: -3.5,
+        right: getAndroidTabletStyle(-3.5, -2.5),
         top: -24,
-        transform: [{rotate: "-11deg"}],
+        transform: [{rotate: getAndroidTabletStyle("-11deg", "-8deg")}],
       }
     })
   },
@@ -53,7 +51,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
         top: getiPadStyle(-26, -26, -29)
       },
       android: {
-        right: 0.4,
+        right: getAndroidTabletStyle(0.4, 0),
         top: -24,
       }
     })

--- a/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
+++ b/app/assets/stylesheets/tablet/tiltedCardComponentStyles.js
@@ -2,6 +2,9 @@ import {StyleSheet, Platform} from 'react-native';
 import color from '../../../themes/color';
 import {cardTitleFontSize} from '../../../constants/component_constant';
 import componentUtil from '../../../utils/component_util';
+import {getiPadStyle} from '../../../utils/responsive_util';
+
+const iOSRotate = getiPadStyle("-8deg", "-7deg", "-5.5deg");
 
 const tiltedCardComponentStyles = StyleSheet.create({
   container: {
@@ -20,7 +23,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
     backgroundColor: color.whiteColor,
     height: 60,
     width: componentUtil.getGridCardWidth() + 2,
-    borderTopRightRadius: 20,
+    borderTopRightRadius: getiPadStyle(20, 20, 12),
     borderTopLeftRadius: 14,
     position: 'absolute',
     borderColor: 'transparent',
@@ -29,7 +32,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
         borderBottomRightRadius: 65.8,
         right: -3,
         top: -23,
-        transform: [{rotate: "-8deg"}],
+        transform: [{rotate: iOSRotate}],
       },
       android: {
         borderBottomRightRadius: 42,
@@ -47,7 +50,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
     ...Platform.select({
       ios: {
         right: 0,
-        top: -26,
+        top: getiPadStyle(-26, -26, -29)
       },
       android: {
         right: 0.4,

--- a/app/components/createAccounts/CreateAccountFormComponent.android.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.android.js
@@ -10,6 +10,7 @@ import asyncStorageService from '../../services/async_storage_service';
 import {navigationRef} from '../../navigators/app_navigator';
 import {USER_INFO_CHANGED} from '../../constants/async_storage_constant';
 import audioSources from '../../constants/audio_source_constant';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const CreateAccountFormComponent = (props) => {
   const {t} = useTranslation();
@@ -59,7 +60,7 @@ const CreateAccountFormComponent = (props) => {
   }
 
   const renderSaveButton = () => {
-    return <BigButtonComponent label={t('saveAndLogin')} style={{marginTop: 16}}
+    return <BigButtonComponent label={t('saveAndLogin')} style={{marginTop: getStyleOfDevice(32, 16)}}
               uuid='123'
               audio={audioSources["0.13.mp3"]}
               playingUuid={playingUuid}

--- a/app/components/createAccounts/CreateAccountFormComponent.ios.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.ios.js
@@ -10,6 +10,7 @@ import asyncStorageService from '../../services/async_storage_service';
 import {navigationRef} from '../../navigators/app_navigator';
 import {USER_INFO_CHANGED} from '../../constants/async_storage_constant';
 import audioSources from '../../constants/audio_source_constant';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const CreateAccountFormComponent = (props) => {
   const {t} = useTranslation();
@@ -59,7 +60,7 @@ const CreateAccountFormComponent = (props) => {
   }
 
   const renderSaveButton = () => {
-    return <BigButtonComponent label={t('saveAndLogin')} style={{marginTop: 16}}
+    return <BigButtonComponent label={t('saveAndLogin')} style={{marginTop: getStyleOfDevice(32, 16)}}
               uuid='123'
               audio={audioSources["0.13.mp3"]}
               playingUuid={playingUuid}

--- a/app/components/introductions/IntroDoneButtonComponent.android.js
+++ b/app/components/introductions/IntroDoneButtonComponent.android.js
@@ -1,18 +1,32 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, StyleSheet} from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import IntroPressableLabelComponent from './IntroPressableLabelComponent';
 import color from '../../themes/color';
 import componentUtil from '../../utils/component_util';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const IntroDoneButtonComponent = (props) => {
   const { t } = useTranslation();
   return (
-    <View style={{alignItems: 'center', backgroundColor: color.primaryColor, borderRadius: 40, elevation: 4, height: componentUtil.mediumPressableItemSize(), justifyContent: 'center', width: '60%', alignSelf: 'center'}}>
+    <View style={styles.container}>
       <IntroPressableLabelComponent label={ t('startUsingApp') } labelStyle={{color: color.whiteColor}} containerStyle={{width: '100%'}} />
     </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    alignSelf: 'center',
+    backgroundColor: color.primaryColor,
+    borderRadius: 40,
+    elevation: 4,
+    height: getStyleOfDevice(componentUtil.tabletPressableItemSize(), componentUtil.mediumPressableItemSize()),
+    justifyContent: 'center',
+    width: '60%',
+  }
+});
 
 export default IntroDoneButtonComponent;

--- a/app/components/introductions/IntroDoneButtonComponent.ios.js
+++ b/app/components/introductions/IntroDoneButtonComponent.ios.js
@@ -1,19 +1,33 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, StyleSheet} from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import IntroPressableLabelComponent from './IntroPressableLabelComponent';
 import color from '../../themes/color';
 import componentUtil from '../../utils/component_util';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 import sharedStyles from '../../assets/stylesheets/shared/sharedStyles';
 
 const IntroDoneButtonComponent = (props) => {
   const { t } = useTranslation();
   return (
-    <View style={[{alignItems: 'center', backgroundColor: color.primaryColor, borderRadius: 40, elevation: 4, height: componentUtil.mediumPressableItemSize(), justifyContent: 'center', width: '60%', alignSelf: 'center'}, sharedStyles.boxShadow]}>
+    <View style={[styles.container, sharedStyles.boxShadow]}>
       <IntroPressableLabelComponent label={ t('startUsingApp') } labelStyle={{color: color.whiteColor}} containerStyle={{width: '100%'}} />
     </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    alignSelf: 'center',
+    backgroundColor: color.primaryColor,
+    borderRadius: 40,
+    elevation: 4,
+    height: getStyleOfDevice(componentUtil.tabletPressableItemSize(), componentUtil.mediumPressableItemSize()),
+    justifyContent: 'center',
+    width: '60%'
+  }
+});
 
 export default IntroDoneButtonComponent;

--- a/app/components/loginSelections/LoginSelectionLineComponent.android.js
+++ b/app/components/loginSelections/LoginSelectionLineComponent.android.js
@@ -2,7 +2,8 @@ import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {useTranslation} from 'react-i18next';
 import color from '../../themes/color';
-import {mediumFontSize} from '../../utils/font_size_util';
+import {mediumFontSize, xxLargeFontSize} from '../../utils/font_size_util';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const LoginSelectionLineComponent = () => {
   const {t} = useTranslation();
@@ -21,7 +22,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     marginVertical: 12,
-    height: 24,
+    height: getStyleOfDevice(40, 24),
     width: 138,
   },
   line: {
@@ -31,7 +32,7 @@ const styles = StyleSheet.create({
   },
   label: {
     color: color.whiteColor,
-    fontSize: mediumFontSize(),
+    fontSize: getStyleOfDevice(xxLargeFontSize(), mediumFontSize()),
     marginHorizontal: 13,
     textAlign: 'center',
   }

--- a/app/components/loginSelections/LoginSelectionLineComponent.ios.js
+++ b/app/components/loginSelections/LoginSelectionLineComponent.ios.js
@@ -3,7 +3,8 @@ import {View, StyleSheet} from 'react-native';
 import {Text} from 'react-native-paper';
 import {useTranslation} from 'react-i18next';
 import color from '../../themes/color';
-import {mediumFontSize} from '../../utils/font_size_util';
+import {mediumFontSize, xxLargeFontSize} from '../../utils/font_size_util';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const LoginSelectionLineComponent = () => {
   const {t} = useTranslation();
@@ -22,7 +23,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     marginVertical: 12,
-    height: 24,
+    height: getStyleOfDevice(40, 24),
     width: 138,
   },
   line: {
@@ -32,7 +33,7 @@ const styles = StyleSheet.create({
   },
   label: {
     color: color.whiteColor,
-    fontSize: mediumFontSize(),
+    fontSize: getStyleOfDevice(xxLargeFontSize(), mediumFontSize()),
     marginHorizontal: 13,
     textAlign: 'center',
   }

--- a/app/components/playVideoModals/PlayVideoModalComponent.android.js
+++ b/app/components/playVideoModals/PlayVideoModalComponent.android.js
@@ -47,6 +47,7 @@ const PlayVideoModalComponent = (props) => {
       style={{width: '100%', margin: 0}}
       backdropColor='black'
       backdropOpacity={0.8}
+      animationOut="zoomOut"
     >
       { !!props.video && renderContent()}
     </Modal>

--- a/app/components/playVideoModals/PlayVideoModalComponent.ios.js
+++ b/app/components/playVideoModals/PlayVideoModalComponent.ios.js
@@ -48,6 +48,7 @@ const PlayVideoModalComponent = (props) => {
       style={{width: '100%', margin: 0}}
       backdropColor='black'
       backdropOpacity={0.8}
+      animationOut="zoomOut"
     >
       { !!props.video && renderContent()}
     </Modal>

--- a/app/components/shared/BigButtonComponent.android.js
+++ b/app/components/shared/BigButtonComponent.android.js
@@ -8,6 +8,7 @@ import color from '../../themes/color';
 import {BUTTON_DELAY_DURATION} from '../../constants/main_constant';
 import componentUtil from '../../utils/component_util';
 import {xLargeFontSize} from '../../utils/font_size_util';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const BigButtonComponent = (props) => {
   const [disabled, setDisabled] = useState(false);
@@ -54,7 +55,7 @@ const styles = StyleSheet.create({
     backgroundColor: color.primaryColor,
     borderRadius: BORDER_RADIUS,
     elevation: 4,
-    height: componentUtil.mediumPressableItemSize(),
+    height: getStyleOfDevice(componentUtil.tabletPressableItemSize(), componentUtil.mediumPressableItemSize()),
     justifyContent: 'center'
   },
   audioBtn: {

--- a/app/components/shared/BigButtonComponent.ios.js
+++ b/app/components/shared/BigButtonComponent.ios.js
@@ -8,6 +8,7 @@ import color from '../../themes/color';
 import {BUTTON_DELAY_DURATION} from '../../constants/main_constant';
 import componentUtil from '../../utils/component_util';
 import {xLargeFontSize} from '../../utils/font_size_util';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const BigButtonComponent = (props) => {
   const [disabled, setDisabled] = useState(false);
@@ -54,7 +55,7 @@ const styles = StyleSheet.create({
     backgroundColor: color.primaryColor,
     borderRadius: BORDER_RADIUS,
     elevation: 4,
-    height: componentUtil.mediumPressableItemSize(),
+    height: getStyleOfDevice(componentUtil.tabletPressableItemSize(), componentUtil.mediumPressableItemSize()),
     justifyContent: 'center'
   },
   audioBtn: {

--- a/app/components/shared/BottomSheetPickerComponent.android.js
+++ b/app/components/shared/BottomSheetPickerComponent.android.js
@@ -8,7 +8,6 @@ import PlayAudioComponent from './PlayAudioComponent';
 import TextComponent from './TextComponent';
 import color from '../../themes/color';
 import { getStyleOfDevice } from '../../utils/responsive_util';
-import componentUtil from '../../utils/component_util';
 import BottomSheetPickerTabletStyles from '../../assets/stylesheets/tablet/bottomSheetPickerComponentStyles';
 import BottomSheetPickerMobileStyles from '../../assets/stylesheets/mobile/bottomSheetPickerComponentStyles';
 
@@ -57,7 +56,7 @@ class BottomSheetPickerComponent extends React.Component {
         <TextComponent label={this.props.title} required={this.props.required} requiredColor={color.blackColor} style={styles.titleLabel} />
 
         <View style={styles.mainContainer}>
-          <TouchableOpacity onPress={() => this.showPicker()} style={{height: componentUtil.mediumPressableItemSize()}}>
+          <TouchableOpacity onPress={() => this.showPicker()} style={{height: '100%'}}>
             <View style={styles.textContainer}>
               {this.renderAudioButton()}
               <View style={{flex: 1}}>

--- a/app/components/shared/BottomSheetPickerComponent.ios.js
+++ b/app/components/shared/BottomSheetPickerComponent.ios.js
@@ -8,7 +8,6 @@ import PlayAudioComponent from './PlayAudioComponent';
 import TextComponent from './TextComponent';
 import color from '../../themes/color';
 import { getStyleOfDevice } from '../../utils/responsive_util';
-import componentUtil from '../../utils/component_util';
 import BottomSheetPickerTabletStyles from '../../assets/stylesheets/tablet/bottomSheetPickerComponentStyles';
 import BottomSheetPickerMobileStyles from '../../assets/stylesheets/mobile/bottomSheetPickerComponentStyles';
 
@@ -57,7 +56,7 @@ class BottomSheetPickerComponent extends React.Component {
         <TextComponent label={this.props.title} required={this.props.required} requiredColor={color.blackColor} style={styles.titleLabel} />
 
         <View style={styles.mainContainer}>
-          <TouchableOpacity onPress={() => this.showPicker()} style={{height: componentUtil.mediumPressableItemSize()}}>
+          <TouchableOpacity onPress={() => this.showPicker()} style={{height: '100%'}}>
             <View style={styles.textContainer}>
               {this.renderAudioButton()}
               <View style={{flex: 1}}>

--- a/app/constants/component_constant.js
+++ b/app/constants/component_constant.js
@@ -16,3 +16,4 @@ export const cardTitleFontSize = xLargeFontSize();
 export const descriptionFontSize = largeFontSize();
 export const descriptionLineHeight = getStyleOfDevice(38, isLowPixelDensityDevice() ? 28 : 36);
 export const navHeaderHeight = 56;
+export const androidBigTabletWidth = 800;

--- a/app/constants/ios_device_constant.js
+++ b/app/constants/ios_device_constant.js
@@ -1,0 +1,3 @@
+export const iPadMiniWidth = 744;
+export const iPadPro11Width = 834;
+export const iPadPro12Width = 1024;

--- a/app/constants/ios_device_constant.js
+++ b/app/constants/ios_device_constant.js
@@ -1,3 +1,3 @@
 export const iPadMiniWidth = 744;
-export const iPadPro11Width = 834;
-export const iPadPro12Width = 1024;
+export const iPadPro11InchesWidth = 834;
+export const iPadPro12InchesWidth = 1024;

--- a/app/utils/component_util.js
+++ b/app/utils/component_util.js
@@ -10,6 +10,7 @@ const componentUtil = (() => {
     mediumPressableItemSize,
     largePressableItemSize,
     getGridCardWidth,
+    tabletPressableItemSize
   }
 
   function pressableItemSize(padding = 0) {
@@ -22,6 +23,10 @@ const componentUtil = (() => {
 
   function largePressableItemSize() {
     return 60;
+  }
+
+  function tabletPressableItemSize() {
+    return 56;
   }
 
   function getGridCardWidth() {

--- a/app/utils/responsive_util.js
+++ b/app/utils/responsive_util.js
@@ -3,6 +3,7 @@ import DeviceInfo from 'react-native-device-info'
 
 import { smallMobileHeight, mediumMobileHeight, smallWidthMobile, XHDPIRatio } from '../constants/screen_size_constant';
 import {iPadPro11Width, iPadPro12Width} from '../constants/ios_device_constant';
+import {androidBigTabletWidth} from '../constants/component_constant';
 
 const screenHeight = Dimensions.get('screen').height;
 const screenWidth = Dimensions.get('screen').width;
@@ -37,6 +38,10 @@ export const getiPadStyle = (smallStyle, mediumStyle, largeStyle) => {
     return largeStyle;
 
   return Dimensions.get('window').width >= iPadPro11Width ? mediumStyle : smallStyle;
+}
+
+export const getAndroidTabletStyle = (smallStyle, mediumStyle) => {
+  return Dimensions.get('window').width >= androidBigTabletWidth ? mediumStyle : smallStyle;
 }
 
 export const isLowPixelDensityDevice = () => {

--- a/app/utils/responsive_util.js
+++ b/app/utils/responsive_util.js
@@ -2,7 +2,7 @@ import { Dimensions, PixelRatio } from 'react-native';
 import DeviceInfo from 'react-native-device-info'
 
 import { smallMobileHeight, mediumMobileHeight, smallWidthMobile, XHDPIRatio } from '../constants/screen_size_constant';
-import {iPadPro11Width, iPadPro12Width} from '../constants/ios_device_constant';
+import {iPadPro11InchesWidth, iPadPro12InchesWidth} from '../constants/ios_device_constant';
 import {androidBigTabletWidth} from '../constants/component_constant';
 
 const screenHeight = Dimensions.get('screen').height;
@@ -34,10 +34,10 @@ export const mobileIconSize = (size) => {
 }
 
 export const getiPadStyle = (smallStyle, mediumStyle, largeStyle) => {
-  if (Dimensions.get('window').width >= iPadPro12Width)
+  if (Dimensions.get('window').width >= iPadPro12InchesWidth)
     return largeStyle;
 
-  return Dimensions.get('window').width >= iPadPro11Width ? mediumStyle : smallStyle;
+  return Dimensions.get('window').width >= iPadPro11InchesWidth ? mediumStyle : smallStyle;
 }
 
 export const getAndroidTabletStyle = (smallStyle, mediumStyle) => {

--- a/app/utils/responsive_util.js
+++ b/app/utils/responsive_util.js
@@ -2,6 +2,7 @@ import { Dimensions, PixelRatio } from 'react-native';
 import DeviceInfo from 'react-native-device-info'
 
 import { smallMobileHeight, mediumMobileHeight, smallWidthMobile, XHDPIRatio } from '../constants/screen_size_constant';
+import {iPadPro11Width, iPadPro12Width} from '../constants/ios_device_constant';
 
 const screenHeight = Dimensions.get('screen').height;
 const screenWidth = Dimensions.get('screen').width;
@@ -29,6 +30,13 @@ export const mobileIconSize = (size) => {
   }
 
   return size;
+}
+
+export const getiPadStyle = (smallStyle, mediumStyle, largeStyle) => {
+  if (Dimensions.get('window').width >= iPadPro12Width)
+    return largeStyle;
+
+  return Dimensions.get('window').width >= iPadPro11Width ? mediumStyle : smallStyle;
 }
 
 export const isLowPixelDensityDevice = () => {


### PR DESCRIPTION
This pull request is updating the UI of the login selection, create account, and home screen when render on tablet devices both iOS and Android.

Below are the screenshots on iOS and Android tablet devices.
- Android: [android tablet.zip](https://github.com/kawsangs/adolescents_app/files/10255533/android.tablet.zip)

- iOS: [iOS tablet.zip](https://github.com/kawsangs/adolescents_app/files/10255535/iOS.tablet.zip)
