### PR TITLE
Add audio player to FAQ detail screen

### DIFF
--- a/app/components/questions/QuestionMainComponent.android.js
+++ b/app/components/questions/QuestionMainComponent.android.js
@@ -7,6 +7,9 @@ import Option from '../../models/Option';
 import {navigationRef} from '../../navigators/app_navigator';
 import {TOPIC, QUESTION, OPTION, QUESTION_FAQ} from '../../constants/faq_constant';
 import topicHelper from '../../helpers/topic_helper';
+import {xLargeFontSize} from '../../utils/font_size_util';
+import {TEXT_SIZE} from '../../constants/async_storage_constant';
+import asyncStorageService from '../../services/async_storage_service';
 
 const QuestionMainComponent = (props) => {
   const [items, setItems] = useState([]);
@@ -28,12 +31,13 @@ const QuestionMainComponent = (props) => {
     props.type == QUESTION ? onPressQuestion(item) : onPressOption(item, moveNext);
   }
 
-  const onPressQuestion = (item) => {
+  const onPressQuestion = async (item) => {
     setPreviousType(QUESTION);
     // Redirect to detail screen if the selected question type is FAQ
     if (item.type == QUESTION_FAQ) {
+      const savedFontSize = await asyncStorageService.getItem(TEXT_SIZE);
       setQuestionUuid(null);
-      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: QUESTION })
+      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: QUESTION, textSize: savedFontSize || xLargeFontSize() })
     }
 
     // If the selected question type is not FAQ then show the options of this question
@@ -43,9 +47,11 @@ const QuestionMainComponent = (props) => {
     props.updateType(OPTION);
   }
 
-  const onPressOption = (item, moveNext) => {
-    if (!moveNext)    // Redirect to detail screen if the selected option move_next = false
-      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: OPTION });
+  const onPressOption = async (item, moveNext) => {
+    if (!moveNext) {   // Redirect to detail screen if the selected option move_next = false
+      const savedFontSize = await asyncStorageService.getItem(TEXT_SIZE);
+      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: OPTION, textSize: savedFontSize || xLargeFontSize() });
+    }
 
     // If the selected option move_next = true then show the next question
     setPreviousType(OPTION);

--- a/app/components/questions/QuestionMainComponent.ios.js
+++ b/app/components/questions/QuestionMainComponent.ios.js
@@ -7,6 +7,9 @@ import Option from '../../models/Option';
 import {navigationRef} from '../../navigators/app_navigator';
 import {TOPIC, QUESTION, OPTION, QUESTION_FAQ} from '../../constants/faq_constant';
 import topicHelper from '../../helpers/topic_helper';
+import {xLargeFontSize} from '../../utils/font_size_util';
+import {TEXT_SIZE} from '../../constants/async_storage_constant';
+import asyncStorageService from '../../services/async_storage_service';
 
 const QuestionMainComponent = (props) => {
   const [items, setItems] = useState([]);
@@ -28,12 +31,13 @@ const QuestionMainComponent = (props) => {
     props.type == QUESTION ? onPressQuestion(item) : onPressOption(item, moveNext);
   }
 
-  const onPressQuestion = (item) => {
+  const onPressQuestion = async (item) => {
     setPreviousType(QUESTION);
     // Redirect to detail screen if the selected question type is FAQ
     if (item.type == QUESTION_FAQ) {
+      const savedFontSize = await asyncStorageService.getItem(TEXT_SIZE);
       setQuestionUuid(null);
-      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: QUESTION })
+      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: QUESTION, textSize: savedFontSize || xLargeFontSize() })
     }
 
     // If the selected question type is not FAQ then show the options of this question
@@ -43,9 +47,11 @@ const QuestionMainComponent = (props) => {
     props.updateType(OPTION);
   }
 
-  const onPressOption = (item, moveNext) => {
-    if (!moveNext)    // Redirect to detail screen if the selected option move_next = false
-      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: OPTION });
+  const onPressOption = async (item, moveNext) => {
+    if (!moveNext) {   // Redirect to detail screen if the selected option move_next = false
+      const savedFontSize = await asyncStorageService.getItem(TEXT_SIZE);
+      return navigationRef.current?.navigate("TopicDetailView", { uuid: item.uuid , name: item.name, topic_uuid: props.topicUuid, type: OPTION, textSize: savedFontSize || xLargeFontSize() });
+    }
 
     // If the selected option move_next = true then show the next question
     setPreviousType(OPTION);

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.android.js
@@ -41,7 +41,7 @@ const HeaderAudioControlButtonsComponent = (props) => {
   return (
     <View style={{flex: 1, paddingHorizontal: screenHorizontalPadding}}>
       <Animated.View style={[styles.audioControl,
-        {transform: [{scaleX: audioControlScale}, {scaleY: audioControlScale}, {translateY: audioControlPositionY}]}]}
+        !props.hideAnimation ? {transform: [{scaleX: audioControlScale}, {scaleY: audioControlScale}, {translateY: audioControlPositionY}]} : {}]}
       >
         <AudioControlButton iconName='play-back' size={forwardBackwardSize}
           onPress={() => audioPlayerService.fastForwardOrReverse(props.audioPlayer, REVERSE)}

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlButtonsComponent.ios.js
@@ -41,7 +41,7 @@ const HeaderAudioControlButtonsComponent = (props) => {
   return (
     <View style={{flex: 1, paddingHorizontal: screenHorizontalPadding}}>
       <Animated.View style={[styles.audioControl,
-        {transform: [{scaleX: audioControlScale}, {scaleY: audioControlScale}, {translateY: audioControlPositionY}]}]}
+        !props.hideAnimation ? {transform: [{scaleX: audioControlScale}, {scaleY: audioControlScale}, {translateY: audioControlPositionY}]} : {}]}
       >
         <AudioControlButton iconName='play-back' size={forwardBackwardSize}
           onPress={() => audioPlayerService.fastForwardOrReverse(props.audioPlayer, REVERSE)}

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlComponent.android.js
@@ -31,7 +31,7 @@ const HeaderAudioControlComponent = (props) => {
 
   return (
     <React.Fragment>
-      <HeaderAudioControlButtonsComponent uuid={props.uuid} audio={props.audio} scrollY={props.scrollY}
+      <HeaderAudioControlButtonsComponent uuid={props.uuid} audio={props.audio} scrollY={props.scrollY} hideAnimation={props.hideAnimation}
         audioPlayer={state.audioPlayer} countInterval={state.countInterval}
         updateAudioPlayer={updateState}
       />
@@ -40,6 +40,7 @@ const HeaderAudioControlComponent = (props) => {
         audioPlayer={state.audioPlayer} duration={state.duration} playSeconds={state.playSeconds}
         countInterval={state.countInterval}
         updateAudioPlayer={updateState}
+        sliderContainerStyle={props.sliderContainerStyle}
       />
     </React.Fragment>
   )

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioControlComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioControlComponent.ios.js
@@ -31,7 +31,7 @@ const HeaderAudioControlComponent = (props) => {
 
   return (
     <React.Fragment>
-      <HeaderAudioControlButtonsComponent uuid={props.uuid} audio={props.audio} scrollY={props.scrollY}
+      <HeaderAudioControlButtonsComponent uuid={props.uuid} audio={props.audio} scrollY={props.scrollY} hideAnimation={props.hideAnimation}
         audioPlayer={state.audioPlayer} countInterval={state.countInterval}
         updateAudioPlayer={updateState}
       />
@@ -40,6 +40,7 @@ const HeaderAudioControlComponent = (props) => {
         audioPlayer={state.audioPlayer} duration={state.duration} playSeconds={state.playSeconds}
         countInterval={state.countInterval}
         updateAudioPlayer={updateState}
+        sliderContainerStyle={props.sliderContainerStyle}
       />
     </React.Fragment>
   )

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.android.js
@@ -34,7 +34,7 @@ const HeaderAudioSliderComponent = (props) => {
   }
 
   return (
-    <View style={styles.sliderContainer}>
+    <View style={[styles.sliderContainer, props.sliderContainerStyle]}>
       <Slider
         value={props.playSeconds}
         disabled={props.playSeconds == props.duration}

--- a/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/HeaderAudioSliderComponent.ios.js
@@ -34,7 +34,7 @@ const HeaderAudioSliderComponent = (props) => {
   }
 
   return (
-    <View style={styles.sliderContainer}>
+    <View style={[styles.sliderContainer, props.sliderContainerStyle]}>
       <Slider
         value={props.playSeconds}
         disabled={props.playSeconds == props.duration}

--- a/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.android.js
+++ b/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.android.js
@@ -7,7 +7,7 @@ import NavigationHeaderBackButtonComponent from '../NavigationHeaderBackButtonCo
 import NavigationHeaderButtonComponent from '../navigationHeaders/NavigationHeaderButtonComponent';
 import NavigationHeaderTitleComponent from '../navigationHeaders/NavigationHeaderTitleComponent';
 import FontSizeSettingModalComponent from '../FontSizeSettingModalComponent';
-import {navigationHeaderIconSize} from '../../../constants/component_constant';
+import {navigationHeaderIconSize, navigationHeaderHorizontalPadding} from '../../../constants/component_constant';
 import {headerWithAudioScrollDistance} from '../../../constants/android_component_constant';
 
 const ScrollViewHeaderNavigationComponent = (props) => {
@@ -25,11 +25,13 @@ const ScrollViewHeaderNavigationComponent = (props) => {
   }
 
   return (
-    <Appbar.Header style={styles.container}>
+    <Appbar.Header style={[styles.container, props.containerStyle]}>
       <NavigationHeaderBackButtonComponent/>
-      <Animated.View style={{flex: 1, paddingLeft: 8, opacity: titleOpacity}}>
-        <NavigationHeaderTitleComponent label={props.title} />
-      </Animated.View>
+      { !!props.customTitle ? props.customTitle
+        : <Animated.View style={{flex: 1, paddingLeft: 8, opacity: titleOpacity}}>
+            <NavigationHeaderTitleComponent label={props.title} />
+          </Animated.View>
+      }
       {renderFontSettingButton()}
 
       <FontSizeSettingModalComponent visible={isModalVisible} onDismiss={() => setIsModalVisible(false)} textSize={props.textSize} updateTextSize={props.updateTextSize} />
@@ -41,6 +43,7 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: 'rgba(0, 0, 0, 0)',
     elevation: 0,
+    paddingHorizontal: navigationHeaderHorizontalPadding,
   },
 });
 

--- a/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.ios.js
+++ b/app/components/shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent.ios.js
@@ -7,7 +7,7 @@ import NavigationHeaderBackButtonComponent from '../NavigationHeaderBackButtonCo
 import NavigationHeaderButtonComponent from '../navigationHeaders/NavigationHeaderButtonComponent';
 import NavigationHeaderTitleComponent from '../navigationHeaders/NavigationHeaderTitleComponent';
 import FontSizeSettingModalComponent from '../FontSizeSettingModalComponent';
-import {navigationHeaderIconSize} from '../../../constants/component_constant';
+import {navigationHeaderIconSize, navigationHeaderHorizontalPadding} from '../../../constants/component_constant';
 import {headerWithAudioScrollDistance} from '../../../constants/ios_component_constant';
 
 const ScrollViewHeaderNavigationComponent = (props) => {
@@ -25,11 +25,13 @@ const ScrollViewHeaderNavigationComponent = (props) => {
   }
 
   return (
-    <Appbar.Header style={styles.container}>
+    <Appbar.Header style={[styles.container, props.containerStyle]}>
       <NavigationHeaderBackButtonComponent/>
-      <Animated.View style={{flex: 1, paddingLeft: 8, opacity: titleOpacity}}>
-        <NavigationHeaderTitleComponent label={props.title} />
-      </Animated.View>
+      { !!props.customTitle ? props.customTitle
+        : <Animated.View style={{flex: 1, paddingLeft: 8, opacity: titleOpacity}}>
+            <NavigationHeaderTitleComponent label={props.title} />
+          </Animated.View>
+      }
       {renderFontSettingButton()}
 
       <FontSizeSettingModalComponent visible={isModalVisible} onDismiss={() => setIsModalVisible(false)} textSize={props.textSize} updateTextSize={props.updateTextSize} />
@@ -41,6 +43,7 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: 'rgba(0, 0, 0, 0)',
     elevation: 0,
+    paddingHorizontal: navigationHeaderHorizontalPadding
   },
 });
 

--- a/app/components/topicDetails/TopicDetailDescriptionComponent.android.js
+++ b/app/components/topicDetails/TopicDetailDescriptionComponent.android.js
@@ -5,14 +5,13 @@ import {Card} from 'react-native-paper';
 import color from '../../themes/color';
 import {descriptionLineHeight, cardBorderRadius, cardElevation} from '../../constants/component_constant';
 import {OPTION} from '../../constants/faq_constant';
-import {descriptionFontSize} from '../../utils/font_size_util';
 import Option from '../../models/Option';
 import Question from '../../models/Question';
 
 const TopicDetailDescription = (props) => {
   return (
     <Card mode="elevated" elevation={cardElevation} style={{borderRadius: cardBorderRadius, paddingBottom: 0}}>
-      <Text style={{fontSize: descriptionFontSize(), lineHeight: descriptionLineHeight, padding: 16, color: color.blackColor}}>
+      <Text style={{fontSize: parseFloat(props.textSize), lineHeight: descriptionLineHeight, padding: 16, color: color.blackColor}}>
         { props.type == OPTION ? Option.findByUuid(props.uuid).message : Question.findByUuid(props.uuid).answer }
       </Text>
     </Card>

--- a/app/components/topicDetails/TopicDetailDescriptionComponent.ios.js
+++ b/app/components/topicDetails/TopicDetailDescriptionComponent.ios.js
@@ -5,14 +5,13 @@ import {Card} from 'react-native-paper';
 import color from '../../themes/color';
 import {descriptionLineHeight, cardBorderRadius, cardElevation} from '../../constants/component_constant';
 import {OPTION} from '../../constants/faq_constant';
-import {descriptionFontSize} from '../../utils/font_size_util';
 import Option from '../../models/Option';
 import Question from '../../models/Question';
 
 const TopicDetailDescription = (props) => {
   return (
     <Card mode="elevated" elevation={cardElevation} style={{borderRadius: cardBorderRadius, paddingBottom: 0}}>
-      <Text style={{fontSize: descriptionFontSize(), lineHeight: descriptionLineHeight, padding: 16, color: color.blackColor}}>
+      <Text style={{fontSize: parseFloat(props.textSize), lineHeight: descriptionLineHeight, padding: 16, color: color.blackColor}}>
         { props.type == OPTION ? Option.findByUuid(props.uuid).message : Question.findByUuid(props.uuid).answer }
       </Text>
     </Card>

--- a/app/components/topicDetails/TopicDetailMainComponent.android.js
+++ b/app/components/topicDetails/TopicDetailMainComponent.android.js
@@ -26,7 +26,7 @@ const TopicDetailMainComponent = (props) => {
   return (
     <React.Fragment>
       <View style={{paddingTop: 16, paddingHorizontal: screenHorizontalPadding}}>
-        <TopicDetailDescriptionComponent uuid={props.uuid} type={props.type} />
+        <TopicDetailDescriptionComponent uuid={props.uuid} type={props.type} textSize={props.textSize} />
         { facilities.length > 0 && <Text style={{marginTop: 20, marginBottom: 0, color: 'white', fontSize: 16}}>{t('recommendedServiceProvider')}</Text>}
         { renderFacilities() }
       </View>

--- a/app/components/topicDetails/TopicDetailMainComponent.ios.js
+++ b/app/components/topicDetails/TopicDetailMainComponent.ios.js
@@ -26,7 +26,7 @@ const TopicDetailMainComponent = (props) => {
   return (
     <React.Fragment>
       <View style={{paddingTop: 16, paddingHorizontal: screenHorizontalPadding, paddingBottom: scrollViewPaddingBottom}}>
-        <TopicDetailDescriptionComponent uuid={props.uuid} type={props.type} />
+        <TopicDetailDescriptionComponent uuid={props.uuid} type={props.type} textSize={props.textSize} />
         { facilities.length > 0 && <Text style={{marginTop: 20, marginBottom: 0, color: 'white', fontSize: 16}}>{t('recommendedServiceProvider')}</Text>}
         { renderFacilities() }
       </View>

--- a/app/components/topicDetails/TopicDetailNavigationHeaderComponent.android.js
+++ b/app/components/topicDetails/TopicDetailNavigationHeaderComponent.android.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import {View, Animated} from 'react-native';
+
+import AutoScrollLabelComponent from '../shared/AutoScrollLabelComponent';
+import HeaderAudioControlComponent from '../shared/scrollViewWithAudios/HeaderAudioControlComponent';
+import ScrollViewHeaderNavigationComponent from '../shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent';
+
+import color from '../../themes/color';
+import Question from '../../models/Question';
+import audioSources from '../../constants/audio_source_constant';
+
+const TopicDetailNavigationHeaderComponent = (props) => {
+  const question = Question.findByUuid(props.uuid)
+
+  return (
+    <React.Fragment>
+      <ScrollViewHeaderNavigationComponent textSize={props.textSize} scrollY={new Animated.Value(0)} updateTextSize={(textSize) => props.updateTextSize(textSize)}
+        customTitle={<AutoScrollLabelComponent label={props.title} />}
+        containerStyle={{backgroundColor: color.primaryColor}}
+      />
+      <View style={{backgroundColor: color.primaryColor, height: 100, zIndex: 1}}>
+        <HeaderAudioControlComponent uuid={props.uuid} audio={audioSources[question.audio]} scrollY={new Animated.Value(0)} hideAnimation={true}
+          sliderContainerStyle={{backgroundColor: 'transparent', marginBottom: -13}}
+        />
+      </View>
+    </React.Fragment>
+  )
+}
+
+export default TopicDetailNavigationHeaderComponent;

--- a/app/components/topicDetails/TopicDetailNavigationHeaderComponent.ios.js
+++ b/app/components/topicDetails/TopicDetailNavigationHeaderComponent.ios.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import {View, Animated} from 'react-native';
+
+import AutoScrollLabelComponent from '../shared/AutoScrollLabelComponent';
+import HeaderAudioControlComponent from '../shared/scrollViewWithAudios/HeaderAudioControlComponent';
+import ScrollViewHeaderNavigationComponent from '../shared/scrollViewWithAudios/ScrollViewHeaderNavigationComponent';
+
+import color from '../../themes/color';
+import Question from '../../models/Question';
+import audioSources from '../../constants/audio_source_constant';
+
+const TopicDetailNavigationHeaderComponent = (props) => {
+  const question = Question.findByUuid(props.uuid)
+
+  return (
+    <React.Fragment>
+      <ScrollViewHeaderNavigationComponent textSize={props.textSize} scrollY={new Animated.Value(0)} updateTextSize={(textSize) => props.updateTextSize(textSize)}
+        customTitle={<AutoScrollLabelComponent label={props.title} />}
+        containerStyle={{backgroundColor: color.primaryColor}}
+      />
+      <View style={{backgroundColor: color.primaryColor, height: 100, zIndex: 1}}>
+        <HeaderAudioControlComponent uuid={props.uuid} audio={audioSources[question.audio]} scrollY={new Animated.Value(0)} hideAnimation={true}
+          sliderContainerStyle={{backgroundColor: 'transparent', marginBottom: -13}}
+        />
+      </View>
+    </React.Fragment>
+  )
+}
+
+export default TopicDetailNavigationHeaderComponent;

--- a/app/components/topics/TopicMainComponent.android.js
+++ b/app/components/topics/TopicMainComponent.android.js
@@ -7,7 +7,10 @@ import Question from '../../models/Question';
 import {navigationRef} from '../../navigators/app_navigator';
 import visitService from '../../services/visit_service';
 import audioPlayerService from '../../services/audio_player_service';
+import asyncStorageService from '../../services/async_storage_service';
 import {QUESTION} from '../../constants/faq_constant';
+import {TEXT_SIZE} from '../../constants/async_storage_constant';
+import {xLargeFontSize} from '../../utils/font_size_util';
 
 const TopicMainComponent = (props) => {
   const [playingUuid, setPlayingUuid] = React.useState(null);
@@ -23,11 +26,12 @@ const TopicMainComponent = (props) => {
     }, [])
   );
 
-  const onPress = (item) => {
+  const onPress = async (item) => {
+    const savedFontSize = await asyncStorageService.getItem(TEXT_SIZE);
     setPlayingUuid(null);
     visitService.recordVisitTopic(item, () => {
       const question = Question.findByUuid(item.question_uuids[0]);
-      navigationRef.current?.navigate("TopicDetailView", { uuid: question.uuid , name: question.name, topic_uuid: item.uuid, type: QUESTION });
+      navigationRef.current?.navigate("TopicDetailView", { uuid: question.uuid , name: question.name, topic_uuid: item.uuid, type: QUESTION, textSize: savedFontSize || xLargeFontSize() });
     });
   }
 

--- a/app/components/topics/TopicMainComponent.ios.js
+++ b/app/components/topics/TopicMainComponent.ios.js
@@ -6,8 +6,11 @@ import Topic from '../../models/Topic';
 import Question from '../../models/Question';
 import {navigationRef} from '../../navigators/app_navigator';
 import visitService from '../../services/visit_service';
+import asyncStorageService from '../../services/async_storage_service';
 import audioPlayerService from '../../services/audio_player_service';
 import {QUESTION} from '../../constants/faq_constant';
+import {TEXT_SIZE} from '../../constants/async_storage_constant';
+import {xLargeFontSize} from '../../utils/font_size_util';
 
 const TopicMainComponent = (props) => {
   const [playingUuid, setPlayingUuid] = React.useState(null);
@@ -23,11 +26,12 @@ const TopicMainComponent = (props) => {
     }, [])
   );
 
-  const onPress = (item) => {
+  const onPress = async (item) => {
+    const savedFontSize = await asyncStorageService.getItem(TEXT_SIZE);
     setPlayingUuid(null);
     visitService.recordVisitTopic(item, () => {
       const question = Question.findByUuid(item.question_uuids[0]);
-      navigationRef.current?.navigate("TopicDetailView", { uuid: question.uuid , name: question.name, topic_uuid: item.uuid, type: QUESTION });
+      navigationRef.current?.navigate("TopicDetailView", { uuid: question.uuid , name: question.name, topic_uuid: item.uuid, type: QUESTION, textSize: savedFontSize || xLargeFontSize() });
     });
   }
 

--- a/app/views/topicDetails/TopicDetailView.android.js
+++ b/app/views/topicDetails/TopicDetailView.android.js
@@ -1,14 +1,13 @@
-import React, {useCallback} from 'react';
-import {Animated} from 'react-native';
+import React, {useCallback, useState} from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 
-import NavigationHeaderWithBackButtonComponent from '../../components/shared/NavigationHeaderWithBackButtonComponent';
-import AutoScrollLabelComponent from '../../components/shared/AutoScrollLabelComponent';
 import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
+import TopicDetailNavigationHeaderComponent from '../../components/topicDetails/TopicDetailNavigationHeaderComponent';
 import TopicDetailMainComponent from '../../components/topicDetails/TopicDetailMainComponent';
 import audioPlayerService from '../../services/audio_player_service';
 
 const TopicDetailView = (props) => {
+  const [textSize, setTextSize] = useState(props.route.params.textSize)
   useFocusEffect(
     useCallback(() => {
       return () => audioPlayerService.clearAllAudio()
@@ -17,9 +16,9 @@ const TopicDetailView = (props) => {
 
   return (
     <GradientScrollViewComponent
-      header={<NavigationHeaderWithBackButtonComponent customTitle={<AutoScrollLabelComponent label={props.route.params.name} />} />}
-      body={<TopicDetailMainComponent uuid={props.route.params.uuid} topicUuid={props.route.params.topic_uuid} type={props.route.params.type} />}
-      scrollViewStyle={{paddingHorizontal: 0}}
+      header={<TopicDetailNavigationHeaderComponent title={props.route.params.name} uuid={props.route.params.uuid} textSize={textSize} updateTextSize={(size) => setTextSize(size)} />}
+      body={<TopicDetailMainComponent uuid={props.route.params.uuid} topicUuid={props.route.params.topic_uuid} type={props.route.params.type} textSize={textSize} />}
+      scrollViewStyle={{paddingHorizontal: 0, paddingTop: 6, paddingBottom: 230}}
     />
   )
 }

--- a/app/views/topicDetails/TopicDetailView.ios.js
+++ b/app/views/topicDetails/TopicDetailView.ios.js
@@ -1,14 +1,14 @@
-import React, {useCallback} from 'react';
-import {Animated} from 'react-native';
+import React, {useCallback, useState} from 'react';
 import { useFocusEffect } from '@react-navigation/native';
+import DeviceInfo from 'react-native-device-info';
 
-import NavigationHeaderWithBackButtonComponent from '../../components/shared/NavigationHeaderWithBackButtonComponent';
-import AutoScrollLabelComponent from '../../components/shared/AutoScrollLabelComponent';
 import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
+import TopicDetailNavigationHeaderComponent from '../../components/topicDetails/TopicDetailNavigationHeaderComponent';
 import TopicDetailMainComponent from '../../components/topicDetails/TopicDetailMainComponent';
 import audioPlayerService from '../../services/audio_player_service';
 
 const TopicDetailView = (props) => {
+  const [textSize, setTextSize] = useState(props.route.params.textSize)
   useFocusEffect(
     useCallback(() => {
       return () => audioPlayerService.clearAllAudio()
@@ -17,9 +17,9 @@ const TopicDetailView = (props) => {
 
   return (
     <GradientScrollViewComponent
-      header={<NavigationHeaderWithBackButtonComponent customTitle={<AutoScrollLabelComponent label={props.route.params.name} />} />}
-      body={<TopicDetailMainComponent uuid={props.route.params.uuid} topicUuid={props.route.params.topic_uuid} type={props.route.params.type} />}
-      scrollViewStyle={{paddingHorizontal: 0}}
+      header={<TopicDetailNavigationHeaderComponent title={props.route.params.name} uuid={props.route.params.uuid} textSize={textSize} updateTextSize={(size) => setTextSize(size)} />}
+      body={<TopicDetailMainComponent uuid={props.route.params.uuid} topicUuid={props.route.params.topic_uuid} type={props.route.params.type} textSize={textSize} />}
+      scrollViewStyle={{paddingHorizontal: 0, paddingTop: 6, paddingBottom: DeviceInfo.hasNotch() ? 220 : 170}}
     />
   )
 }


### PR DESCRIPTION
This pull request is adding the audio player to the FAQ detail screen similar to the category detail screen, the user is able to play/pause the audio and update the font size of the content, but the header will not show the shrink animation when the user scrolls the content.

Below are the screenshots of the FAQ detail screen on iOS and Android both mobile and tablet devices:
[FAQ detail.zip](https://github.com/kawsangs/adolescents_app/files/10380367/FAQ.detail.zip)
