### PR TITLE
Hotfix use device unique id instead of the device id when sending to…

### DIFF
--- a/app/services/app_user_service.js
+++ b/app/services/app_user_service.js
@@ -59,7 +59,7 @@ const createAccountService = (() => {
 
   function _sendCreateRequest(params, callback) {
     networkService.checkConnection(async () => {
-      const response = await new AppUserApi().post(_userApiParams(params));
+      const response = await new AppUserApi().post(await _userApiParams(params));
       apiService.handleApiResponse(response, (res) => {
         User.update(params.uuid, { id: res.id, synced: true });
         !!callback && callback();
@@ -85,13 +85,14 @@ const createAccountService = (() => {
     return params;
   }
 
-  function _userApiParams(user) {
+  async function _userApiParams(user) {
     const characteristicAttrs = [];
     user.characteristics.map(characteristic => {
       characteristicAttrs.push({ characteristic_attributes: { code: characteristic } });
     });
-    const params = {
-      device_id: DeviceInfo.getDeviceId(),
+
+    let params = {
+      device_id: await DeviceInfo.getUniqueId(),
       app_user_characteristics_attributes: characteristicAttrs,
       registered_at: user.registered_at,
       province_id: user.province_id,
@@ -99,7 +100,6 @@ const createAccountService = (() => {
       age: user.age,
       platform: Platform.OS
     }
-
     return params;
   }
 })();

--- a/app/services/mobile_token_service.js
+++ b/app/services/mobile_token_service.js
@@ -99,11 +99,11 @@ const MobileTokenService = (() => {
     })
   }
 
-  function _sendToken(token, id=null) {
+  async function _sendToken(token, id=null) {
     let data =  {
       mobile_token: {
         token: token,
-        device_id: DeviceInfo.getDeviceId(),
+        device_id: await DeviceInfo.getUniqueId(),
         device_type: DeviceInfo.isTablet() ? 'tablet' : 'mobile',
         app_version: DeviceInfo.getVersion(),
         platform: Platform.OS,


### PR DESCRIPTION
This pull request is making a hotfix on using the device's unique id instead of the device id when sending to the API (mobile token and create user API).

The unique id is generated as follows (the same on iOS & Android):
- The same device generates the same unique id (uninstall and reinstall the app)
- Different device with the same model and OS version generates a different unique id
- Different device with the same model and different OS version generates a different unique id
- Different device with different model and OS version generates a different unique id