### PR TITLE
Remove the isInternetReachable state from the condition before sendin…

### DIFF
--- a/app/services/mobile_token_service.js
+++ b/app/services/mobile_token_service.js
@@ -94,7 +94,7 @@ const MobileTokenService = (() => {
 
   function handleSyncingToken() {
     NetInfo.fetch().then(state => {
-      if (state.isConnected && state.isInternetReachable)
+      if (state.isConnected)
         requestUserPermission();
     });
   }


### PR DESCRIPTION
This pull request removes the isInternetReachable state on the condition that will check the network info before requesting the firebase token because on iOS devices the isInternetReachable returns null, so it will not send the request to get the firebase token.