### PR TITLE
Make the isInternetReachable works on iOS device

### DIFF
--- a/app/services/mobile_token_service.js
+++ b/app/services/mobile_token_service.js
@@ -93,6 +93,17 @@ const MobileTokenService = (() => {
   }
 
   function handleSyncingToken() {
+    if (Platform.OS == 'ios') {
+      // iOS the isInternetReachable will return as null on app launches, using event listener in order to get the true/false value.
+      const unsubscribe = NetInfo.addEventListener(state => {
+        if (state.isConnected && state.isInternetReachable) {
+          unsubscribe();
+          requestUserPermission();
+        }
+      });
+      return;
+    }
+
     NetInfo.fetch().then(state => {
       if (state.isConnected && state.isInternetReachable)
         requestUserPermission();


### PR DESCRIPTION
This pull request is making the device NetInfo isInternetReachable works on the iOS device by separating between iOS and Android for checking the network info.
- on iOS: need to use the NetInfo event listener in order to get the isInternetReachable state true/false because when the app launches the isInternetReachable will return as null.

- on Android: not using the NetInfo.addEventListener to prevent the function requestUserPermission from calling twice because the first time the app launches the isInternetReachable will return true/false (using event listener will call the requestUserPermission twice since the isInternetReachable is not returned as null when the app launches).