### PR TITLE
Fix the style of the bottom sheet picker in the facility filter screen

### DIFF
--- a/app/components/createAccounts/CreateAccountSelectionsComponent.android.js
+++ b/app/components/createAccounts/CreateAccountSelectionsComponent.android.js
@@ -7,7 +7,6 @@ import characteristics from '../../db/data/characteristics';
 import userHelper from '../../helpers/user_helper';
 import audioSources from '../../constants/audio_source_constant';
 import color from '../../themes/color';
-import {defaultPickerContentHeight} from '../../constants/modal_constant';
 
 const CreateAccountSelectionsComponent = (props) => {
   const {t, i18n} = useTranslation();
@@ -29,7 +28,6 @@ const CreateAccountSelectionsComponent = (props) => {
               updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
               containerStyle={{marginTop: sectionMarginTop}}
               hideListItemAudio={true}
-              pickerContentHeight={defaultPickerContentHeight}
            />
   }
 
@@ -48,7 +46,6 @@ const CreateAccountSelectionsComponent = (props) => {
               playingUuid={props.playingUuid}
               updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
               containerStyle={{marginTop: sectionMarginTop}}
-              pickerContentHeight={defaultPickerContentHeight}
            />
   }
 

--- a/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
+++ b/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
@@ -7,7 +7,6 @@ import characteristics from '../../db/data/characteristics';
 import userHelper from '../../helpers/user_helper';
 import audioSources from '../../constants/audio_source_constant';
 import color from '../../themes/color';
-import {defaultPickerContentHeight} from '../../constants/modal_constant';
 
 const CreateAccountSelectionsComponent = (props) => {
   const {t, i18n} = useTranslation();
@@ -29,7 +28,6 @@ const CreateAccountSelectionsComponent = (props) => {
               updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
               containerStyle={{marginTop: sectionMarginTop}}
               hideListItemAudio={true}
-              pickerContentHeight={defaultPickerContentHeight}
            />
   }
 
@@ -48,7 +46,6 @@ const CreateAccountSelectionsComponent = (props) => {
               playingUuid={props.playingUuid}
               updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
               containerStyle={{marginTop: sectionMarginTop}}
-              pickerContentHeight={defaultPickerContentHeight}
            />
   }
 

--- a/app/components/shared/CustomBottomSheetPickerComponent.android.js
+++ b/app/components/shared/CustomBottomSheetPickerComponent.android.js
@@ -4,6 +4,7 @@ import {BottomSheetPicker} from 'react-native-bottom-sheet-picker';
 import color from '../../themes/color';
 import {FontFamily} from '../../themes/font';
 import {titleFontSize, bottomSheetTitleFontSize, itemFontSize} from '../../constants/bottom_sheet_picker_constant';
+import {defaultPickerContentHeight} from '../../constants/modal_constant';
 
 const CustomBottomSheetPickerComponent = (props) => {
   const colorSet = (type) => {
@@ -25,6 +26,7 @@ const CustomBottomSheetPickerComponent = (props) => {
             bottomSheetTitleStyle={{fontSize: bottomSheetTitleFontSize, fontFamily: FontFamily.bold}}
             placeholderStyle={[{fontSize: itemFontSize, fontFamily: FontFamily.regular, alignSelf: 'center', color: colorSet('text')}, props.placeholderStyle]}
             itemTextStyle={{fontSize: itemFontSize, fontFaimly: FontFamily.regular}}
+            pickerContentHeight={defaultPickerContentHeight}
           />
 }
 


### PR DESCRIPTION
This pull request fixes the height of the bottom sheet picker in the facility filter screen so it can render all the items inside it and sets a default height for all bottom sheet pickers on Android devices (iOS is already set on the previous pull request).