### PR TITLE
Create profile detail screen

### DIFF
--- a/app/assets/stylesheets/mobile/profileInfoListItemComponentStyles.js
+++ b/app/assets/stylesheets/mobile/profileInfoListItemComponentStyles.js
@@ -1,0 +1,35 @@
+import {StyleSheet} from 'react-native';
+import {descriptionFontSize} from '../../../constants/component_constant';
+
+const profileInfoComponentStyles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    paddingVertical: 6
+  },
+  infoWrapper: {
+    alignItems: 'center',
+    flex: 10,
+    flexDirection: 'row'
+  },
+  label: {
+    fontSize: descriptionFontSize,
+    flex: 6,
+    marginTop: 4
+  },
+  valueWrapper: {
+    alignItems: 'center',
+    flex: 6,
+    flexDirection: 'row',
+    justifyContent: 'center'
+  },
+  valueLabel: {
+    fontSize: descriptionFontSize,
+    fontWeight: 'bold'
+  },
+  audioWrapper: {
+    flex: 2
+  }
+});
+
+export default profileInfoComponentStyles;

--- a/app/assets/stylesheets/tablet/profileInfoListItemComponentStyles.js
+++ b/app/assets/stylesheets/tablet/profileInfoListItemComponentStyles.js
@@ -1,0 +1,37 @@
+import {StyleSheet} from 'react-native';
+import {descriptionFontSize} from '../../../constants/component_constant';
+
+const profileInfoComponentStyles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    paddingVertical: 6
+  },
+  infoWrapper: {
+    alignItems: 'center',
+    flex: 10,
+    flexDirection: 'row'
+  },
+  label: {
+    fontSize: descriptionFontSize,
+    flex: 6,
+    marginTop: 4
+  },
+  valueWrapper: {
+    alignItems: 'center',
+    flex: 6,
+    flexDirection: 'row',
+    justifyContent: 'center'
+  },
+  valueLabel: {
+    fontSize: descriptionFontSize,
+    fontWeight: 'bold'
+  },
+  audioWrapper: {
+    alignItems: 'flex-end',
+    flex: 2,
+    paddingRight: 4
+  }
+});
+
+export default profileInfoComponentStyles;

--- a/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.android.js
+++ b/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.android.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, TouchableOpacity} from 'react-native';
 import {Text} from 'react-native-paper';
 import FeatherIcon from 'react-native-vector-icons/Feather';
 import {useTranslation} from 'react-i18next';
@@ -10,6 +10,7 @@ import color from '../../themes/color';
 import {largeFontSize} from '../../utils/font_size_util';
 import translationHelper from '../../helpers/translation_helper';
 import User from '../../models/User';
+import {navigationRef} from '../../navigators/app_navigator';
 
 const DrawerNavigatorHeaderComponent = (props) => {
   const {t, i18n} = useTranslation();
@@ -20,7 +21,9 @@ const DrawerNavigatorHeaderComponent = (props) => {
   }
 
   return (
-    <View style={{flexDirection: 'row', borderWidth: 0, marginTop: 40, alignItems: 'center'}}>
+    <TouchableOpacity onPress={() => navigationRef.current?.navigate('ProfileView')}
+      style={{flexDirection: 'row', borderWidth: 0, marginTop: 40, alignItems: 'center'}}
+    >
       <GradientViewComponent style={{ width: 64, height: 64, borderRadius: 64, justifyContent: 'center', alignItems: 'center', elevation: 4 }}>
         {renderIcon()}
       </GradientViewComponent>
@@ -31,7 +34,8 @@ const DrawerNavigatorHeaderComponent = (props) => {
           : t('anonymous')
         }
       </Text>
-    </View>
+      <FeatherIcon name="chevron-right" color={color.whiteColor} size={22} style={{marginLeft: 10, marginTop: -2}} />
+    </TouchableOpacity>
   )
 }
 

--- a/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
+++ b/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, TouchableOpacity} from 'react-native';
 import {Text} from 'react-native-paper';
 import FeatherIcon from 'react-native-vector-icons/Feather';
 import {useTranslation} from 'react-i18next';
@@ -10,6 +10,7 @@ import color from '../../themes/color';
 import {largeFontSize} from '../../utils/font_size_util';
 import translationHelper from '../../helpers/translation_helper';
 import User from '../../models/User';
+import {navigationRef} from '../../navigators/app_navigator';
 
 const DrawerNavigatorHeaderComponent = (props) => {
   const {t, i18n} = useTranslation();
@@ -20,7 +21,9 @@ const DrawerNavigatorHeaderComponent = (props) => {
   }
 
   return (
-    <View style={{flexDirection: 'row', borderWidth: 0, marginTop: 40, alignItems: 'center'}}>
+    <TouchableOpacity onPress={() => navigationRef.current?.navigate('ProfileView')}
+      style={{flexDirection: 'row', borderWidth: 0, marginTop: 40, alignItems: 'center'}}
+    >
       <GradientViewComponent style={{ width: 64, height: 64, borderRadius: 64, justifyContent: 'center', alignItems: 'center', elevation: 4 }}>
         {renderIcon()}
       </GradientViewComponent>
@@ -30,7 +33,9 @@ const DrawerNavigatorHeaderComponent = (props) => {
           {t(loggedInUser.gender)} | {translationHelper.translateNumber(loggedInUser.age, i18n.language)} {t('year')}
         </Text>
       }
-    </View>
+
+      <FeatherIcon name="chevron-right" color={color.whiteColor} size={22} style={{marginLeft: 10}} />
+    </TouchableOpacity>
   )
 }
 

--- a/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
+++ b/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
@@ -28,11 +28,12 @@ const DrawerNavigatorHeaderComponent = (props) => {
         {renderIcon()}
       </GradientViewComponent>
 
-      { !loggedInUser.anonymous &&
-        <Text style={{color: color.whiteColor, marginLeft: 16, fontSize: largeFontSize()}}>
-          {t(loggedInUser.gender)} | {translationHelper.translateNumber(loggedInUser.age, i18n.language)} {t('year')}
-        </Text>
-      }
+      <Text style={{color: color.whiteColor, marginLeft: 16, fontSize: largeFontSize()}}>
+        {!loggedInUser.anonymous ?
+          `${t(loggedInUser.gender)} | ${translationHelper.translateNumber(loggedInUser.age, i18n.language)} ${t('year')}`
+          : t('anonymous')
+        }
+      </Text>
 
       <FeatherIcon name="chevron-right" color={color.whiteColor} size={22} style={{marginLeft: 10}} />
     </TouchableOpacity>

--- a/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
+++ b/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
@@ -34,8 +34,7 @@ const DrawerNavigatorHeaderComponent = (props) => {
           : t('anonymous')
         }
       </Text>
-
-      <FeatherIcon name="chevron-right" color={color.whiteColor} size={22} style={{marginLeft: 10}} />
+      <FeatherIcon name="chevron-right" color={color.whiteColor} size={22} style={{marginLeft: 10, marginTop: 2}} />
     </TouchableOpacity>
   )
 }

--- a/app/components/drawerNavigators/DrawerNavigatorItemsComponent.android.js
+++ b/app/components/drawerNavigators/DrawerNavigatorItemsComponent.android.js
@@ -5,15 +5,11 @@ import {useDispatch} from 'react-redux';
 
 import DrawerNavigatorItemComponent from './DrawerNavigatorItemComponent';
 import {isLowPixelDensityDevice, getStyleOfDevice} from '../../utils/responsive_util';
-import navigationService from '../../services/navigation_service';
 import {APP_DOWNLOAD_URL, PRIVACY_POLICY_URL, TERMS_AND_CONDITIONS_URL} from '../../constants/main_constant';
-import SearchHistory from '../../models/SearchHistory';
-import {setIsGridView} from '../../features/subCategories/subCategoryDisplayModeSlice';
 
 const SCREEN = 'sc';
 const LINK = 'li';
 const SHARE = 'sh';
-const LOG_OUT = 'lo';
 
 const DrawerNavigatorItemsComponent = (props) => {
   const {t} = useTranslation();
@@ -21,13 +17,12 @@ const DrawerNavigatorItemsComponent = (props) => {
   const renderItems = () => {
     const items = {
       first: [
-        {label: t('about'), icon: 'info', url: 'AboutUsView', type: SCREEN, accessibility_label: 'ប៊ូតុងអំពីកម្មវិធី'},
+        {label: t('share'), icon: 'share-2', url: '', type: SHARE, accessibility_label: 'ប៊ូតុងចែករំលែកកម្មវិធី'},
         {label: t('privacyPolicy'), icon: 'shield', url: PRIVACY_POLICY_URL, type: LINK, accessibility_label: 'ប៊ូតុងគោលការណ៍ឯកជនភាព'},
         {label: t('termsAndConditions'), icon: 'file-text', url: TERMS_AND_CONDITIONS_URL, type: LINK, accessibility_label: 'ប៊ូតុងគោលការណ៍ និងលក្ខខណ្ឌ'},
       ],
       second: [
-        {label: t('share'), icon: 'share-2', url: '', type: SHARE, accessibility_label: 'ប៊ូតុងចែករំលែកកម្មវិធី'},
-        {label: t('reset'), icon: 'rotate-ccw', url: '', type: LOG_OUT, accessibility_label: 'ប៊ូតុងចាប់ផ្ដើមសាជាថ្មី'},
+        {label: t('about'), icon: 'info', url: 'AboutUsView', type: SCREEN, accessibility_label: 'ប៊ូតុងអំពីកម្មវិធី'},
       ]
     }
     const mobileMarginTop = isLowPixelDensityDevice() ? 16 : 34;
@@ -47,12 +42,7 @@ const DrawerNavigatorItemsComponent = (props) => {
   }
 
   const onPress = (url, type) => {
-    if (type == LOG_OUT) {
-      dispatch(setIsGridView(true))
-      SearchHistory.deleteAll();
-      return navigationService.logOut();
-    }
-    else if (type == LINK)
+    if (type == LINK)
       return Linking.openURL(url)
     else if (type == SHARE)
       return shareApp();
@@ -73,7 +63,6 @@ const DrawerNavigatorItemsComponent = (props) => {
 
   return (
     <View style={{marginTop: 40}}>
-      {/* <DrawerNavigatorItemComponent label="កែប្រែអត្តសញ្ញាណ" iconName="edit"/> */}
       {renderItems()}
     </View>
   )

--- a/app/components/drawerNavigators/DrawerNavigatorItemsComponent.ios.js
+++ b/app/components/drawerNavigators/DrawerNavigatorItemsComponent.ios.js
@@ -18,7 +18,6 @@ const DrawerNavigatorItemsComponent = (props) => {
     const items = {
       first: [
         {label: t('share'), icon: 'share-2', url: '', type: SHARE, accessibility_label: 'ប៊ូតុងចែករំលែកកម្មវិធី'},
-        {label: t('about'), icon: 'info', url: 'AboutUsView', type: SCREEN, accessibility_label: 'ប៊ូតុងអំពីកម្មវិធី'},
         {label: t('privacyPolicy'), icon: 'shield', url: PRIVACY_POLICY_URL, type: LINK, accessibility_label: 'ប៊ូតុងគោលការណ៍ឯកជនភាព'},
         {label: t('termsAndConditions'), icon: 'file-text', url: TERMS_AND_CONDITIONS_URL, type: LINK, accessibility_label: 'ប៊ូតុងគោលការណ៍ និងលក្ខខណ្ឌ'},
       ],

--- a/app/components/drawerNavigators/DrawerNavigatorItemsComponent.ios.js
+++ b/app/components/drawerNavigators/DrawerNavigatorItemsComponent.ios.js
@@ -5,15 +5,11 @@ import {useDispatch} from 'react-redux';
 
 import DrawerNavigatorItemComponent from './DrawerNavigatorItemComponent';
 import {isLowPixelDensityDevice, getStyleOfDevice} from '../../utils/responsive_util';
-import navigationService from '../../services/navigation_service';
 import {APP_DOWNLOAD_URL, PRIVACY_POLICY_URL, TERMS_AND_CONDITIONS_URL} from '../../constants/main_constant';
-import SearchHistory from '../../models/SearchHistory';
-import {setIsGridView} from '../../features/subCategories/subCategoryDisplayModeSlice';
 
 const SCREEN = 'sc';
 const LINK = 'li';
 const SHARE = 'sh';
-const LOG_OUT = 'lo';
 
 const DrawerNavigatorItemsComponent = (props) => {
   const {t} = useTranslation();
@@ -21,13 +17,13 @@ const DrawerNavigatorItemsComponent = (props) => {
   const renderItems = () => {
     const items = {
       first: [
+        {label: t('share'), icon: 'share-2', url: '', type: SHARE, accessibility_label: 'ប៊ូតុងចែករំលែកកម្មវិធី'},
         {label: t('about'), icon: 'info', url: 'AboutUsView', type: SCREEN, accessibility_label: 'ប៊ូតុងអំពីកម្មវិធី'},
         {label: t('privacyPolicy'), icon: 'shield', url: PRIVACY_POLICY_URL, type: LINK, accessibility_label: 'ប៊ូតុងគោលការណ៍ឯកជនភាព'},
         {label: t('termsAndConditions'), icon: 'file-text', url: TERMS_AND_CONDITIONS_URL, type: LINK, accessibility_label: 'ប៊ូតុងគោលការណ៍ និងលក្ខខណ្ឌ'},
       ],
       second: [
-        {label: t('share'), icon: 'share-2', url: '', type: SHARE, accessibility_label: 'ប៊ូតុងចែករំលែកកម្មវិធី'},
-        {label: t('reset'), icon: 'rotate-ccw', url: '', type: LOG_OUT, accessibility_label: 'ប៊ូតុងចាប់ផ្ដើមសាជាថ្មី'},
+        {label: t('about'), icon: 'info', url: 'AboutUsView', type: SCREEN, accessibility_label: 'ប៊ូតុងអំពីកម្មវិធី'},
       ]
     }
     const mobileMarginTop = isLowPixelDensityDevice() ? 16 : 34;
@@ -47,12 +43,7 @@ const DrawerNavigatorItemsComponent = (props) => {
   }
 
   const onPress = (url, type) => {
-    if (type == LOG_OUT) {
-      dispatch(setIsGridView(true))
-      SearchHistory.deleteAll();
-      return navigationService.logOut();
-    }
-    else if (type == LINK)
+    if (type == LINK)
       return Linking.openURL(url)
     else if (type == SHARE)
       return shareApp();
@@ -73,7 +64,6 @@ const DrawerNavigatorItemsComponent = (props) => {
 
   return (
     <View style={{marginTop: 40}}>
-      {/* <DrawerNavigatorItemComponent label="កែប្រែអត្តសញ្ញាណ" iconName="edit"/> */}
       {renderItems()}
     </View>
   )

--- a/app/components/profiles/ProfileCharacteristicsComponent.android.js
+++ b/app/components/profiles/ProfileCharacteristicsComponent.android.js
@@ -7,22 +7,25 @@ import {descriptionFontSize} from '../../constants/component_constant';
 import profileHelper from '../../helpers/profile_helper';
 import User from '../../models/User';
 import {getStyleOfDevice} from '../../utils/responsive_util';
+import tabletStyles from '../../assets/stylesheets/tablet/profileInfoListItemComponentStyles';
+import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemComponentStyles';
+
+const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
 const ProfileCharacteristicsComponent = (props) => {
   let characteristics = [];
     User.currentLoggedIn().characteristics.map((characteristic, index) => {
       const charac = profileHelper.getCharacteristic(characteristic)
-      characteristics.push(<View key={charac.value} style={{flexDirection: 'row', alignItems: 'center'}}>
-                              <View style={{flex: getStyleOfDevice(11, 10)}}>
-                                <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold', marginLeft: 20}}>{charac.name_km}</Text>
+      characteristics.push(<View key={charac.value} style={{flexDirection: 'row', alignItems: 'center', marginVertical: 2}}>
+                              <View style={styles.infoWrapper}>
+                                <Text style={[{marginLeft: 20}, styles.valueLabel]}>{charac.name_km}</Text>
                               </View>
-                              <View style={{flex: getStyleOfDevice(1, 2), borderWidth: 1}}>
+                              <View style={styles.audioWrapper}>
                                 <CustomAudioPlayerButtonComponent
                                   audio={charac.audio}
                                   itemUuid={charac.value}
                                   playingUuid={props.playingUuid}
                                   updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
-                                  buttonStyle={{borderRadius: 0, height: 52}}
                                 />
                               </View>
                            </View>

--- a/app/components/profiles/ProfileCharacteristicsComponent.android.js
+++ b/app/components/profiles/ProfileCharacteristicsComponent.android.js
@@ -13,29 +13,30 @@ import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemCom
 const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
 const ProfileCharacteristicsComponent = (props) => {
-  let characteristics = [];
-    User.currentLoggedIn().characteristics.map((characteristic, index) => {
-      const charac = profileHelper.getCharacteristic(characteristic)
-      characteristics.push(<View key={charac.value} style={{flexDirection: 'row', alignItems: 'center', marginVertical: 2}}>
-                              <View style={styles.infoWrapper}>
-                                <Text style={[{marginLeft: 20}, styles.valueLabel]}>{charac.name_km}</Text>
-                              </View>
-                              <View style={styles.audioWrapper}>
-                                <CustomAudioPlayerButtonComponent
-                                  audio={charac.audio}
-                                  itemUuid={charac.value}
-                                  playingUuid={props.playingUuid}
-                                  updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
-                                />
-                              </View>
-                           </View>
-                          )
+  renderItems = () => {
+    return User.currentLoggedIn().characteristics.map(characteristic => {
+      const characObj = profileHelper.getCharacteristic(characteristic)
+      return (<View key={characObj.uuid} style={{flexDirection: 'row', alignItems: 'center', marginVertical: 2}}>
+                <View style={styles.infoWrapper}>
+                  <Text style={[{marginLeft: 20}, styles.valueLabel]}>{characObj.name_km}</Text>
+                </View>
+                <View style={styles.audioWrapper}>
+                  <CustomAudioPlayerButtonComponent
+                    audio={characObj.audio}
+                    itemUuid={characObj.uuid}
+                    playingUuid={props.playingUuid}
+                    updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+                  />
+                </View>
+              </View>
+            )
     })
+  }
 
-    return <React.Fragment>
-              <Text style={{fontSize: descriptionFontSize, marginBottom: 6}}>ស្ថានភាពរស់នៅ</Text>
-              {characteristics}
-           </React.Fragment>
+  return <React.Fragment>
+            <Text style={{fontSize: descriptionFontSize, marginBottom: 6, marginTop: 6}}>ស្ថានភាពរស់នៅ</Text>
+            {renderItems()}
+          </React.Fragment>
 }
 
 export default ProfileCharacteristicsComponent;

--- a/app/components/profiles/ProfileCharacteristicsComponent.ios.js
+++ b/app/components/profiles/ProfileCharacteristicsComponent.ios.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Text} from 'react-native-paper';
+
+import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
+import {descriptionFontSize} from '../../constants/component_constant';
+import profileHelper from '../../helpers/profile_helper';
+import User from '../../models/User';
+
+const ProfileCharacteristicsComponent = (props) => {
+  let characteristics = [];
+    User.currentLoggedIn().characteristics.map((characteristic, index) => {
+      const charac = profileHelper.getCharacteristic(characteristic)
+      characteristics.push(<View key={charac.value} style={{flexDirection: 'row', marginLeft: 20, alignItems: 'center', borderWidth: 0}}>
+                              <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold', flex: 1}}>{charac.name_km}</Text>
+                              <CustomAudioPlayerButtonComponent
+                                audio={charac.audio}
+                                itemUuid={charac.value}
+                                playingUuid={props.playingUuid}
+                                updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+                                buttonStyle={{borderRadius: 0, borderWidth: 0, height: 52}}
+                              />
+                           </View>
+                          )
+    })
+
+    return <React.Fragment>
+              <Text style={{fontSize: descriptionFontSize, marginBottom: 6}}>ស្ថានភាពរស់នៅ</Text>
+              {characteristics}
+           </React.Fragment>
+}
+
+export default ProfileCharacteristicsComponent;

--- a/app/components/profiles/ProfileCharacteristicsComponent.ios.js
+++ b/app/components/profiles/ProfileCharacteristicsComponent.ios.js
@@ -7,22 +7,25 @@ import {descriptionFontSize} from '../../constants/component_constant';
 import profileHelper from '../../helpers/profile_helper';
 import User from '../../models/User';
 import {getStyleOfDevice} from '../../utils/responsive_util';
+import tabletStyles from '../../assets/stylesheets/tablet/profileInfoListItemComponentStyles';
+import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemComponentStyles';
+
+const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
 const ProfileCharacteristicsComponent = (props) => {
   let characteristics = [];
     User.currentLoggedIn().characteristics.map((characteristic, index) => {
       const charac = profileHelper.getCharacteristic(characteristic)
-      characteristics.push(<View key={charac.value} style={{flexDirection: 'row', alignItems: 'center'}}>
-                              <View style={{flex: getStyleOfDevice(11, 10)}}>
-                                <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold', marginLeft: 20}}>{charac.name_km}</Text>
+      characteristics.push(<View key={charac.value} style={{flexDirection: 'row', alignItems: 'center', marginVertical: 2}}>
+                              <View style={styles.infoWrapper}>
+                                <Text style={[{marginLeft: 20}, styles.valueLabel]}>{charac.name_km}</Text>
                               </View>
-                              <View style={{flex: getStyleOfDevice(1, 2), borderWidth: 1}}>
+                              <View style={styles.audioWrapper}>
                                 <CustomAudioPlayerButtonComponent
                                   audio={charac.audio}
                                   itemUuid={charac.value}
                                   playingUuid={props.playingUuid}
                                   updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
-                                  buttonStyle={{borderRadius: 0, height: 52}}
                                 />
                               </View>
                            </View>

--- a/app/components/profiles/ProfileCharacteristicsComponent.ios.js
+++ b/app/components/profiles/ProfileCharacteristicsComponent.ios.js
@@ -13,29 +13,30 @@ import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemCom
 const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
 const ProfileCharacteristicsComponent = (props) => {
-  let characteristics = [];
-    User.currentLoggedIn().characteristics.map((characteristic, index) => {
-      const charac = profileHelper.getCharacteristic(characteristic)
-      characteristics.push(<View key={charac.value} style={{flexDirection: 'row', alignItems: 'center', marginVertical: 2}}>
-                              <View style={styles.infoWrapper}>
-                                <Text style={[{marginLeft: 20}, styles.valueLabel]}>{charac.name_km}</Text>
-                              </View>
-                              <View style={styles.audioWrapper}>
-                                <CustomAudioPlayerButtonComponent
-                                  audio={charac.audio}
-                                  itemUuid={charac.value}
-                                  playingUuid={props.playingUuid}
-                                  updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
-                                />
-                              </View>
-                           </View>
-                          )
+  renderItems = () => {
+    return User.currentLoggedIn().characteristics.map(characteristic => {
+      const characObj = profileHelper.getCharacteristic(characteristic)
+      return (<View key={characObj.uuid} style={{flexDirection: 'row', alignItems: 'center', marginVertical: 2}}>
+                <View style={styles.infoWrapper}>
+                  <Text style={[{marginLeft: 20}, styles.valueLabel]}>{characObj.name_km}</Text>
+                </View>
+                <View style={styles.audioWrapper}>
+                  <CustomAudioPlayerButtonComponent
+                    audio={characObj.audio}
+                    itemUuid={characObj.uuid}
+                    playingUuid={props.playingUuid}
+                    updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+                  />
+                </View>
+              </View>
+            )
     })
+  }
 
-    return <React.Fragment>
-              <Text style={{fontSize: descriptionFontSize, marginBottom: 6}}>ស្ថានភាពរស់នៅ</Text>
-              {characteristics}
-           </React.Fragment>
+  return <React.Fragment>
+            <Text style={{fontSize: descriptionFontSize, marginBottom: 6, marginTop: 6}}>ស្ថានភាពរស់នៅ</Text>
+            {renderItems()}
+          </React.Fragment>
 }
 
 export default ProfileCharacteristicsComponent;

--- a/app/components/profiles/ProfileInfoComponent.android.js
+++ b/app/components/profiles/ProfileInfoComponent.android.js
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import {View} from 'react-native';
 import {Card} from 'react-native-paper';
 import {useTranslation} from 'react-i18next';
 
@@ -14,7 +15,6 @@ const ProfileInfoComponent = () => {
   const [playingUuid, setPlayingUuid] = useState(null);
   const {t, i18n} = useTranslation();
   const loggedInUser = User.currentLoggedIn();
-
 
   renderInfo = () => {
     const gender = profileHelper.getGender(loggedInUser.gender);

--- a/app/components/profiles/ProfileInfoComponent.android.js
+++ b/app/components/profiles/ProfileInfoComponent.android.js
@@ -11,8 +11,7 @@ import User from '../../models/User';
 import translationHelper from '../../helpers/translation_helper';
 import profileHelper from '../../helpers/profile_helper';
 
-const ProfileInfoComponent = () => {
-  const [playingUuid, setPlayingUuid] = useState(null);
+const ProfileInfoComponent = (props) => {
   const {t, i18n} = useTranslation();
   const loggedInUser = User.currentLoggedIn();
 
@@ -40,16 +39,16 @@ const ProfileInfoComponent = () => {
       }
     ]
     return infos.map((info, index) => {
-     return <ProfileInfoListItemComponent key={info.uuid} info={info} gender={gender} playingUuid={playingUuid} hasIcon={index == 0}
-              updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+     return <ProfileInfoListItemComponent key={info.uuid} info={info} gender={gender} playingUuid={props.playingUuid} hasIcon={index == 0}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
             />
     })
   }
 
   renderAnonymousInfo = () => {
     return anonymousInfo.map((info, index) => {
-      return <ProfileInfoListItemComponent key={index} info={info} gender={null} playingUuid={playingUuid} hasIcon={false}
-              updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+      return <ProfileInfoListItemComponent key={index} info={info} gender={null} playingUuid={props.playingUuid} hasIcon={false}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
               containerStyle={{paddingVertical: 16, paddingBottom: 10}}
             />
     })
@@ -63,8 +62,8 @@ const ProfileInfoComponent = () => {
       { !loggedInUser.anonymous ? renderInfo() : renderAnonymousInfo()}
       { loggedInUser.characteristics.length > 0 &&
         <ProfileCharacteristicsComponent
-          playingUuid={playingUuid}
-          updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+          playingUuid={props.playingUuid}
+          updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
         />
       }
     </Card>

--- a/app/components/profiles/ProfileInfoComponent.ios.js
+++ b/app/components/profiles/ProfileInfoComponent.ios.js
@@ -1,0 +1,78 @@
+import React, {useState} from 'react';
+import {View} from 'react-native';
+import {Text, Card} from 'react-native-paper';
+import {useTranslation} from 'react-i18next';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import ProfileCharacteristicsComponent from './ProfileCharacteristicsComponent';
+import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
+import {descriptionFontSize} from '../../constants/component_constant';
+import {cardBorderRadius, cardElevation} from '../../constants/component_constant';
+import User from '../../models/User';
+import translationHelper from '../../helpers/translation_helper';
+import profileHelper from '../../helpers/profile_helper';
+
+const ProfileInfoComponent = () => {
+  const [playingUuid, setPlayingUuid] = useState(null);
+  const {t, i18n} = useTranslation();
+  const loggedInUser = User.currentLoggedIn();
+
+  const renderInfo = () => {
+    const gender = profileHelper.getGender(loggedInUser.gender);
+    const province = profileHelper.getProvince(loggedInUser.province_id)
+    const infos = [
+      {
+        uuid: 'user-gender',
+        label: 'អត្តសញ្ញាណយែនឌ័រ',
+        value: gender.name_km,
+        audio: gender.audio,
+      },
+      {
+        uuid: 'user-age',
+        label: 'អាយុ',
+        value: `${translationHelper.translateNumber(loggedInUser.age, i18n.language)} ${t('year')}`,
+        audio: null,
+      },
+      {
+        uuid: 'user-province',
+        label: 'ទីតាំង',
+        value: province.name_km,
+        audio: province.audio,
+      }
+    ]
+    return infos.map((info, index) => {
+      return <View style={{flexDirection: 'row', paddingVertical: 6, alignItems: 'center'}} key={info.uuid}>
+                <Text style={{flex: 6, fontSize: descriptionFontSize}}>{info.label}</Text>
+                <View style={{flex: 4, justifyContent: 'center', alignItems: 'center', flexDirection: 'row'}}>
+                  {index == 0 && <Icon name={gender.icon} size={30} style={{marginRight: 8}} />}
+                  <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold'}}>{info.value}</Text>
+                </View>
+                <View style={{flex: 2, alignItems: 'center'}}>
+                  { !!info.audio &&
+                    <CustomAudioPlayerButtonComponent
+                      audio={info.audio}
+                      itemUuid={info.uuid}
+                      playingUuid={playingUuid}
+                      updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+                      buttonStyle={{borderRadius: 0}}
+                    />
+                  }
+                </View>
+             </View>
+    })
+  }
+
+  return (
+    <Card mode="elevated" elevation={cardElevation} style={{borderRadius: cardBorderRadius, marginTop: 16, paddingLeft: 16, paddingBottom: 10}}>
+      { loggedInUser.age != -1 && renderInfo()}
+      { loggedInUser.characteristics.length > 0 &&
+        <ProfileCharacteristicsComponent
+          playingUuid={playingUuid}
+          updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+        />
+      }
+    </Card>
+  )
+}
+
+export default ProfileInfoComponent;

--- a/app/components/profiles/ProfileInfoComponent.ios.js
+++ b/app/components/profiles/ProfileInfoComponent.ios.js
@@ -11,8 +11,7 @@ import translationHelper from '../../helpers/translation_helper';
 import profileHelper from '../../helpers/profile_helper';
 import {getStyleOfDevice} from '../../utils/responsive_util';
 
-const ProfileInfoComponent = () => {
-  const [playingUuid, setPlayingUuid] = useState(null);
+const ProfileInfoComponent = (props) => {
   const {t, i18n} = useTranslation();
   const loggedInUser = User.currentLoggedIn();
 
@@ -41,16 +40,16 @@ const ProfileInfoComponent = () => {
       }
     ]
     return infos.map((info, index) => {
-     return <ProfileInfoListItemComponent key={info.uuid} info={info} gender={gender} playingUuid={playingUuid} hasIcon={index == 0}
-              updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+     return <ProfileInfoListItemComponent key={info.uuid} info={info} gender={gender} playingUuid={props.playingUuid} hasIcon={index == 0}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
             />
     })
   }
 
   renderAnonymousInfo = () => {
     return anonymousInfo.map((info, index) => {
-      return <ProfileInfoListItemComponent key={index} info={info} gender={null} playingUuid={playingUuid} hasIcon={false}
-              updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+      return <ProfileInfoListItemComponent key={index} info={info} gender={null} playingUuid={props.playingUuid} hasIcon={false}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
               containerStyle={{paddingVertical: 16, paddingBottom: 10}}
             />
     })
@@ -64,8 +63,8 @@ const ProfileInfoComponent = () => {
       { !loggedInUser.anonymous ? renderInfo() : renderAnonymousInfo()}
       { loggedInUser.characteristics.length > 0 &&
         <ProfileCharacteristicsComponent
-          playingUuid={playingUuid}
-          updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+          playingUuid={props.playingUuid}
+          updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
         />
       }
     </Card>

--- a/app/components/profiles/ProfileInfoComponent.ios.js
+++ b/app/components/profiles/ProfileInfoComponent.ios.js
@@ -9,6 +9,7 @@ import {anonymousInfo} from '../../constants/user_constant';
 import User from '../../models/User';
 import translationHelper from '../../helpers/translation_helper';
 import profileHelper from '../../helpers/profile_helper';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const ProfileInfoComponent = () => {
   const [playingUuid, setPlayingUuid] = useState(null);
@@ -55,7 +56,7 @@ const ProfileInfoComponent = () => {
     })
   }
 
-  const paddingBottom = (loggedInUser.anonymous || loggedInUser.characteristics.length > 0) ? 8 : 0;
+  const paddingBottom = (loggedInUser.anonymous || loggedInUser.characteristics.length > 0) ? getStyleOfDevice(10, 8) : 0;
   return (
     <Card mode="elevated" elevation={cardElevation}
       style={{borderRadius: cardBorderRadius, marginTop: 16, paddingLeft: 16, paddingBottom: paddingBottom}}

--- a/app/components/profiles/ProfileInfoComponent.ios.js
+++ b/app/components/profiles/ProfileInfoComponent.ios.js
@@ -1,13 +1,11 @@
 import React, {useState} from 'react';
-import {View} from 'react-native';
-import {Text, Card} from 'react-native-paper';
+import {Card} from 'react-native-paper';
 import {useTranslation} from 'react-i18next';
-import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import ProfileCharacteristicsComponent from './ProfileCharacteristicsComponent';
-import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
-import {descriptionFontSize} from '../../constants/component_constant';
+import ProfileInfoListItemComponent from './ProfileInfoListItemComponent';
 import {cardBorderRadius, cardElevation} from '../../constants/component_constant';
+import {anonymousInfo} from '../../constants/user_constant';
 import User from '../../models/User';
 import translationHelper from '../../helpers/translation_helper';
 import profileHelper from '../../helpers/profile_helper';
@@ -17,7 +15,8 @@ const ProfileInfoComponent = () => {
   const {t, i18n} = useTranslation();
   const loggedInUser = User.currentLoggedIn();
 
-  const renderInfo = () => {
+
+  renderInfo = () => {
     const gender = profileHelper.getGender(loggedInUser.gender);
     const province = profileHelper.getProvince(loggedInUser.province_id)
     const infos = [
@@ -41,30 +40,24 @@ const ProfileInfoComponent = () => {
       }
     ]
     return infos.map((info, index) => {
-      return <View style={{flexDirection: 'row', paddingVertical: 6, alignItems: 'center'}} key={info.uuid}>
-                <Text style={{flex: 6, fontSize: descriptionFontSize}}>{info.label}</Text>
-                <View style={{flex: 4, justifyContent: 'center', alignItems: 'center', flexDirection: 'row'}}>
-                  {index == 0 && <Icon name={gender.icon} size={30} style={{marginRight: 8}} />}
-                  <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold'}}>{info.value}</Text>
-                </View>
-                <View style={{flex: 2, alignItems: 'center'}}>
-                  { !!info.audio &&
-                    <CustomAudioPlayerButtonComponent
-                      audio={info.audio}
-                      itemUuid={info.uuid}
-                      playingUuid={playingUuid}
-                      updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
-                      buttonStyle={{borderRadius: 0}}
-                    />
-                  }
-                </View>
-             </View>
+     return <ProfileInfoListItemComponent key={info.uuid} info={info} gender={gender} playingUuid={playingUuid} hasIcon={index == 0}
+              updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+            />
+    })
+  }
+
+  renderAnonymousInfo = () => {
+    return anonymousInfo.map((info, index) => {
+      return <ProfileInfoListItemComponent key={index} info={info} gender={null} playingUuid={playingUuid} hasIcon={false}
+              updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}
+              containerStyle={{paddingVertical: 16, paddingBottom: 10}}
+            />
     })
   }
 
   return (
     <Card mode="elevated" elevation={cardElevation} style={{borderRadius: cardBorderRadius, marginTop: 16, paddingLeft: 16, paddingBottom: 10}}>
-      { loggedInUser.age != -1 && renderInfo()}
+      { !loggedInUser.anonymous ? renderInfo() : renderAnonymousInfo()}
       { loggedInUser.characteristics.length > 0 &&
         <ProfileCharacteristicsComponent
           playingUuid={playingUuid}

--- a/app/components/profiles/ProfileInfoListItemComponent.android.js
+++ b/app/components/profiles/ProfileInfoListItemComponent.android.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Text} from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
+import color from '../../themes/color';
+import {getStyleOfDevice} from '../../utils/responsive_util';
+import tabletStyles from '../../assets/stylesheets/tablet/profileInfoListItemComponentStyles';
+import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemComponentStyles';
+
+const styles = getStyleOfDevice(tabletStyles, mobileStyles);
+
+const ProfileInfoListItem = (props) => {
+  const {info, gender, playingUuid} = props;
+  return <View style={[styles.container, props.containerStyle]}>
+            <View style={styles.infoWrapper}>
+              <Text style={styles.label}>{info.label}</Text>
+              <View style={styles.valueWrapper}>
+                {props.hasIcon && <Icon name={gender.icon} size={30} style={{marginRight: 8}} color={color.lightBlackColor} />}
+                <Text style={styles.valueLabel}>{info.value}</Text>
+              </View>
+            </View>
+            <View style={styles.audioWrapper}>
+              { !!info.audio &&
+                <CustomAudioPlayerButtonComponent
+                  audio={info.audio}
+                  itemUuid={info.uuid}
+                  playingUuid={playingUuid}
+                  updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+                />
+              }
+            </View>
+         </View>
+}
+
+export default ProfileInfoListItem;

--- a/app/components/profiles/ProfileInfoListItemComponent.ios.js
+++ b/app/components/profiles/ProfileInfoListItemComponent.ios.js
@@ -5,16 +5,18 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
 import {descriptionFontSize} from '../../constants/component_constant';
+import color from '../../themes/color';
+import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const ProfileInfoListItem = (props) => {
   const {info, gender, playingUuid} = props;
   return <View style={[styles.container, props.containerStyle]}>
             <Text style={{flex: 6, fontSize: descriptionFontSize}}>{info.label}</Text>
-            <View style={{flex: 4, justifyContent: 'center', alignItems: 'center', flexDirection: 'row'}}>
-              {props.hasIcon && <Icon name={gender.icon} size={30} style={{marginRight: 8}} />}
+            <View style={{flex: getStyleOfDevice(5, 4), justifyContent: 'center', alignItems: 'center', flexDirection: 'row'}}>
+              {props.hasIcon && <Icon name={gender.icon} size={30} style={{marginRight: 8}} color={color.lightBlackColor} />}
               <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold'}}>{info.value}</Text>
             </View>
-            <View style={{flex: 2, alignItems: 'center'}}>
+            <View style={{flex: getStyleOfDevice(1, 2), alignItems: 'flex-end', paddingRight: getStyleOfDevice(2, 1)}}>
               { !!info.audio &&
                 <CustomAudioPlayerButtonComponent
                   audio={info.audio}

--- a/app/components/profiles/ProfileInfoListItemComponent.ios.js
+++ b/app/components/profiles/ProfileInfoListItemComponent.ios.js
@@ -1,41 +1,37 @@
 import React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View} from 'react-native';
 import {Text} from 'react-native-paper';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
-import {descriptionFontSize} from '../../constants/component_constant';
 import color from '../../themes/color';
 import {getStyleOfDevice} from '../../utils/responsive_util';
+import tabletStyles from '../../assets/stylesheets/tablet/profileInfoListItemComponentStyles';
+import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemComponentStyles';
+
+const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
 const ProfileInfoListItem = (props) => {
   const {info, gender, playingUuid} = props;
   return <View style={[styles.container, props.containerStyle]}>
-            <Text style={{flex: 6, fontSize: descriptionFontSize}}>{info.label}</Text>
-            <View style={{flex: getStyleOfDevice(5, 4), justifyContent: 'center', alignItems: 'center', flexDirection: 'row'}}>
-              {props.hasIcon && <Icon name={gender.icon} size={30} style={{marginRight: 8}} color={color.lightBlackColor} />}
-              <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold'}}>{info.value}</Text>
+            <View style={styles.infoWrapper}>
+              <Text style={styles.label}>{info.label}</Text>
+              <View style={styles.valueWrapper}>
+                {props.hasIcon && <Icon name={gender.icon} size={30} style={{marginRight: 8}} color={color.lightBlackColor} />}
+                <Text style={styles.valueLabel}>{info.value}</Text>
+              </View>
             </View>
-            <View style={{flex: getStyleOfDevice(1, 2), alignItems: 'flex-end', paddingRight: getStyleOfDevice(2, 1)}}>
+            <View style={styles.audioWrapper}>
               { !!info.audio &&
                 <CustomAudioPlayerButtonComponent
                   audio={info.audio}
                   itemUuid={info.uuid}
                   playingUuid={playingUuid}
                   updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
-                  buttonStyle={{borderRadius: 0}}
                 />
               }
             </View>
-          </View>
+         </View>
 }
-
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    paddingVertical: 6
-  }
-})
 
 export default ProfileInfoListItem;

--- a/app/components/profiles/ProfileInfoListItemComponent.ios.js
+++ b/app/components/profiles/ProfileInfoListItemComponent.ios.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {View, StyleSheet} from 'react-native';
+import {Text} from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
+import {descriptionFontSize} from '../../constants/component_constant';
+
+const ProfileInfoListItem = (props) => {
+  const {info, gender, playingUuid} = props;
+  return <View style={[styles.container, props.containerStyle]}>
+            <Text style={{flex: 6, fontSize: descriptionFontSize}}>{info.label}</Text>
+            <View style={{flex: 4, justifyContent: 'center', alignItems: 'center', flexDirection: 'row'}}>
+              {props.hasIcon && <Icon name={gender.icon} size={30} style={{marginRight: 8}} />}
+              <Text style={{fontSize: descriptionFontSize, fontWeight: 'bold'}}>{info.value}</Text>
+            </View>
+            <View style={{flex: 2, alignItems: 'center'}}>
+              { !!info.audio &&
+                <CustomAudioPlayerButtonComponent
+                  audio={info.audio}
+                  itemUuid={info.uuid}
+                  playingUuid={playingUuid}
+                  updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+                  buttonStyle={{borderRadius: 0}}
+                />
+              }
+            </View>
+          </View>
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    paddingVertical: 6
+  }
+})
+
+export default ProfileInfoListItem;

--- a/app/components/profiles/ProfileMainComponent.android.js
+++ b/app/components/profiles/ProfileMainComponent.android.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import {View} from 'react-native';
 import FeatherIcon from 'react-native-vector-icons/Feather';
-import DeviceInfo from 'react-native-device-info';
 
 import ProfileInfoComponent from './ProfileInfoComponent';
 import BigButtonComponent from '../shared/BigButtonComponent';
 import color from '../../themes/color';
 import SearchHistory from '../../models/SearchHistory';
 import navigationService from '../../services/navigation_service';
-import {getStyleOfDevice} from '../../utils/responsive_util';
 
 const ProfileMainComponent = () => {
   onPress = () => {
@@ -24,8 +22,8 @@ const ProfileMainComponent = () => {
         <BigButtonComponent
           label='ចាប់ផ្ដើមសាជាថ្មី'
           hideAudio={true}
-          style={{marginBottom: DeviceInfo.hasNotch() ? 26 : getStyleOfDevice(26, 16), flexDirection: 'row', width: 'auto', alignSelf: 'center', paddingHorizontal: 20}}
-          icon={<FeatherIcon name='rotate-ccw' color={color.primaryColor} size={17} style={{marginLeft: 14}} />}
+          style={{marginBottom: 16, flexDirection: 'row', width: 'auto', alignSelf: 'center', paddingHorizontal: 20}}
+          icon={<FeatherIcon name='rotate-ccw' color={color.primaryColor} size={20} style={{marginLeft: 14}} />}
           onPress={() => onPress()}
         />
       </View>

--- a/app/components/profiles/ProfileMainComponent.android.js
+++ b/app/components/profiles/ProfileMainComponent.android.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import {View} from 'react-native';
-import FeatherIcon from 'react-native-vector-icons/Feather';
 
 import ProfileInfoComponent from './ProfileInfoComponent';
 import BigButtonComponent from '../shared/BigButtonComponent';
-import color from '../../themes/color';
 import SearchHistory from '../../models/SearchHistory';
 import navigationService from '../../services/navigation_service';
+import audioSources from '../../constants/audio_source_constant';
 
-const ProfileMainComponent = () => {
+const ProfileMainComponent = (props) => {
   onPress = () => {
     SearchHistory.deleteAll();
     navigationService.logOut();
@@ -16,14 +15,16 @@ const ProfileMainComponent = () => {
 
   return (
     <View style={{flexGrow: 1, flexDirection: 'column'}}>
-      <ProfileInfoComponent/>
+      <ProfileInfoComponent playingUuid={props.playingUuid} updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}/>
       <View style={{flex: 1}} />
       <View>
         <BigButtonComponent
           label='ចាប់ផ្ដើមសាជាថ្មី'
-          hideAudio={true}
-          style={{marginBottom: 16, flexDirection: 'row', width: 'auto', alignSelf: 'center', paddingHorizontal: 20}}
-          icon={<FeatherIcon name='rotate-ccw' color={color.primaryColor} size={20} style={{marginLeft: 14}} />}
+          uuid='reset-button'
+          style={{marginBottom: 16}}
+          audio={null}
+          playingUuid={props.playingUuid}
+          updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
           onPress={() => onPress()}
         />
       </View>

--- a/app/components/profiles/ProfileMainComponent.ios.js
+++ b/app/components/profiles/ProfileMainComponent.ios.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import {View} from 'react-native';
-import FeatherIcon from 'react-native-vector-icons/Feather';
 import DeviceInfo from 'react-native-device-info';
 
 import ProfileInfoComponent from './ProfileInfoComponent';
 import BigButtonComponent from '../shared/BigButtonComponent';
-import color from '../../themes/color';
 import SearchHistory from '../../models/SearchHistory';
 import navigationService from '../../services/navigation_service';
 import {getStyleOfDevice} from '../../utils/responsive_util';
+import audioSources from '../../constants/audio_source_constant';
 
-const ProfileMainComponent = () => {
+const ProfileMainComponent = (props) => {
   onPress = () => {
     SearchHistory.deleteAll();
     navigationService.logOut();
@@ -18,14 +17,16 @@ const ProfileMainComponent = () => {
 
   return (
     <View style={{flexGrow: 1, flexDirection: 'column'}}>
-      <ProfileInfoComponent/>
+      <ProfileInfoComponent playingUuid={props.playingUuid} updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}/>
       <View style={{flex: 1}} />
       <View>
         <BigButtonComponent
           label='ចាប់ផ្ដើមសាជាថ្មី'
-          hideAudio={true}
-          style={{marginBottom: DeviceInfo.hasNotch() ? 26 : getStyleOfDevice(26, 16), flexDirection: 'row', width: 'auto', alignSelf: 'center', paddingHorizontal: 20}}
-          icon={<FeatherIcon name='rotate-ccw' color={color.primaryColor} size={17} style={{marginLeft: 14}} />}
+          uuid='reset-button'
+          style={{marginBottom: DeviceInfo.hasNotch() ? 26 : getStyleOfDevice(26, 16)}}
+          audio={null}
+          playingUuid={props.playingUuid}
+          updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
           onPress={() => onPress()}
         />
       </View>

--- a/app/components/profiles/ProfileMainComponent.ios.js
+++ b/app/components/profiles/ProfileMainComponent.ios.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import {View} from 'react-native';
+import FeatherIcon from 'react-native-vector-icons/Feather';
+
+import ProfileInfoComponent from './ProfileInfoComponent';
+import BigButtonComponent from '../shared/BigButtonComponent';
+import color from '../../themes/color';
+import SearchHistory from '../../models/SearchHistory';
+import navigationService from '../../services/navigation_service';
+
+const ProfileMainComponent = () => {
+  onPress = () => {
+    SearchHistory.deleteAll();
+    navigationService.logOut();
+  }
+
+  return (
+    <View style={{flexGrow: 1, flexDirection: 'column'}}>
+      <ProfileInfoComponent/>
+      <View style={{flex: 1}} />
+      <View>
+        <BigButtonComponent
+          label='ចាប់ផ្ដើមសាជាថ្មី'
+          hideAudio={true}
+          style={{marginBottom: 16, flexDirection: 'row', width: '50%', alignSelf: 'center'}}
+          icon={<FeatherIcon name='rotate-ccw' color={color.primaryColor} size={20} style={{marginLeft: 14}} />}
+          onPress={() => onPress()}
+        />
+      </View>
+    </View>
+  )
+}
+
+export default ProfileMainComponent;

--- a/app/components/shared/BigButtonComponent.android.js
+++ b/app/components/shared/BigButtonComponent.android.js
@@ -43,7 +43,8 @@ const BigButtonComponent = (props) => {
       disabled={props.disabled || disabled}
     >
       <BoldLabelComponent label={props.label} style={{ fontSize: xLargeFontSize(), color: colorSet().textColor, marginTop: getStyleOfDevice(6, 2) }} />
-      {renderAudioBtn()}
+      {!!props.icon && props.icon}
+      {!props.hideAudio && renderAudioBtn()}
     </TouchableOpacity>
   )
 }

--- a/app/components/shared/BigButtonComponent.android.js
+++ b/app/components/shared/BigButtonComponent.android.js
@@ -43,7 +43,6 @@ const BigButtonComponent = (props) => {
       disabled={props.disabled || disabled}
     >
       <BoldLabelComponent label={props.label} style={{ fontSize: xLargeFontSize(), color: colorSet().textColor, marginTop: getStyleOfDevice(6, 2) }} />
-      {!!props.icon && props.icon}
       {!props.hideAudio && renderAudioBtn()}
     </TouchableOpacity>
   )

--- a/app/components/shared/BigButtonComponent.ios.js
+++ b/app/components/shared/BigButtonComponent.ios.js
@@ -43,7 +43,8 @@ const BigButtonComponent = (props) => {
       disabled={props.disabled || disabled}
     >
       <BoldLabelComponent label={props.label} style={{ fontSize: xLargeFontSize(), color: colorSet().textColor }} />
-      {renderAudioBtn()}
+      {!!props.icon && props.icon}
+      {!props.hideAudio && renderAudioBtn()}
     </TouchableOpacity>
   )
 }

--- a/app/components/shared/BigButtonComponent.ios.js
+++ b/app/components/shared/BigButtonComponent.ios.js
@@ -43,7 +43,6 @@ const BigButtonComponent = (props) => {
       disabled={props.disabled || disabled}
     >
       <BoldLabelComponent label={props.label} style={{ fontSize: xLargeFontSize(), color: colorSet().textColor }} />
-      {!!props.icon && props.icon}
       {!props.hideAudio && renderAudioBtn()}
     </TouchableOpacity>
   )

--- a/app/components/shared/NavigationHeaderWithBackButtonComponent.android.js
+++ b/app/components/shared/NavigationHeaderWithBackButtonComponent.android.js
@@ -6,7 +6,7 @@ import NavigationHeaderBackButtonComponent from './NavigationHeaderBackButtonCom
 const NavigationHeaderWithBackButtonComponent = (props) => {
   return (
       <NavigationHeaderComponent
-        leftButton={<NavigationHeaderBackButtonComponent/>}
+        leftButton={<NavigationHeaderBackButtonComponent onPress={props.onPress}/>}
         customTitle={props.customTitle}
         label={props.label}
         headerStyle={props.headerStyle}

--- a/app/components/shared/NavigationHeaderWithBackButtonComponent.ios.js
+++ b/app/components/shared/NavigationHeaderWithBackButtonComponent.ios.js
@@ -6,7 +6,7 @@ import NavigationHeaderBackButtonComponent from './NavigationHeaderBackButtonCom
 const NavigationHeaderWithBackButtonComponent = (props) => {
   return (
       <NavigationHeaderComponent
-        leftButton={<NavigationHeaderBackButtonComponent/>}
+        leftButton={<NavigationHeaderBackButtonComponent onPress={props.onPress}/>}
         customTitle={props.customTitle}
         label={props.label}
         headerStyle={props.headerStyle}

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -5,6 +5,7 @@ export const environment = {
   type: 'development',
   showIntroSlider: true,
   defaultLanguage: KM,
+  // sentryDSN: 'https://d252675dfeb049a0adf1ef7a4abe1b86@o952154.ingest.sentry.io/5901440',
   sentryDSN: '',
   encryptionKey: '',        // Use 256 bytes key
   apiKey: 'c7bfd9081b2e8d10a7a09c6cf32d141e',

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -5,7 +5,6 @@ export const environment = {
   type: 'development',
   showIntroSlider: true,
   defaultLanguage: KM,
-  // sentryDSN: 'https://d252675dfeb049a0adf1ef7a4abe1b86@o952154.ingest.sentry.io/5901440',
   sentryDSN: '',
   encryptionKey: '',        // Use 256 bytes key
   apiKey: 'c7bfd9081b2e8d10a7a09c6cf32d141e',

--- a/app/constants/user_constant.js
+++ b/app/constants/user_constant.js
@@ -1,2 +1,24 @@
 export const minimumAge = 13;
 export const maximumAge = 51;
+
+
+export const anonymousInfo = [
+  {
+    uuid: 'user-gender',
+    label: 'អត្តសញ្ញាណយែនឌ័រ',
+    value: 'មិនមាន',
+    audio: null,
+  },
+  {
+    uuid: 'user-age',
+    label: 'អាយុ',
+    value: 'មិនមាន',
+    audio: null,
+  },
+  {
+    uuid: 'user-province',
+    label: 'ទីតាំង',
+    value: 'មិនមាន',
+    audio: null,
+  }
+]

--- a/app/constants/user_constant.js
+++ b/app/constants/user_constant.js
@@ -6,19 +6,25 @@ export const anonymousInfo = [
   {
     uuid: 'user-gender',
     label: 'អត្តសញ្ញាណយែនឌ័រ',
-    value: 'មិនមាន',
+    value: 'អនាមិក',
     audio: null,
   },
   {
     uuid: 'user-age',
     label: 'អាយុ',
-    value: 'មិនមាន',
+    value: 'អនាមិក',
     audio: null,
   },
   {
     uuid: 'user-province',
     label: 'ទីតាំង',
-    value: 'មិនមាន',
+    value: 'អនាមិក',
+    audio: null,
+  },
+  {
+    uuid: 'user-characteristic',
+    label: 'ស្ថានភាពរស់នៅ',
+    value: 'អនាមិក',
     audio: null,
   }
 ]

--- a/app/db/data/characteristics.js
+++ b/app/db/data/characteristics.js
@@ -1,7 +1,7 @@
 import audioSources from '../../constants/audio_source_constant';
 
 export default [
-  { "name_km": "មានប័ណ្ណសមធម៌(ប័ណ្ណក្រីក្រ)", "name_en": "ID poor", "value": "PO", "audio": audioSources["0.10.mp3"] },
-  { "name_km": "ជនជាតិដើមភាគតិច", "name_en": "Indigenous people", "value": "MI", "audio": audioSources["0.11.mp3"] },
-  { "name_km": "ជនមានពិការភាព", "name_en": "Disability", "value": "DI", "audio": audioSources["0.12.mp3"]}
+  { "name_km": "មានប័ណ្ណសមធម៌(ប័ណ្ណក្រីក្រ)", "name_en": "ID poor", "value": "PO", "audio": audioSources["0.10.mp3"], uuid: "characteristic-po" },
+  { "name_km": "ជនជាតិដើមភាគតិច", "name_en": "Indigenous people", "value": "MI", "audio": audioSources["0.11.mp3"], uuid: "characteristic-mi" },
+  { "name_km": "ជនមានពិការភាព", "name_en": "Disability", "value": "DI", "audio": audioSources["0.12.mp3"], uuid: "characteristic-di"}
 ]

--- a/app/helpers/profile_helper.js
+++ b/app/helpers/profile_helper.js
@@ -1,0 +1,25 @@
+import genders from '../db/data/genders';
+import provinces from '../db/data/provinces';
+import characteristics from '../db/data/characteristics';
+
+const profileHelper = (() => {
+  return {
+    getGender,
+    getProvince,
+    getCharacteristic
+  }
+
+  function getGender(value) {
+    return genders.find(gender => gender.value == value);
+  }
+
+  function getProvince(id) {
+    return provinces.find(province => province.value == id);
+  }
+
+  function getCharacteristic(value) {
+    return characteristics.find(characteristic => characteristic.value == value)
+  }
+})()
+
+export default profileHelper;

--- a/app/navigators/drawer_navigator.js
+++ b/app/navigators/drawer_navigator.js
@@ -4,6 +4,7 @@ import { createDrawerNavigator } from '@react-navigation/drawer';
 import BottomTabNavigator from './bottom_tab_navigator';
 import DrawerNavigatorComponent from '../components/drawerNavigators/DrawerNavigatorComponent';
 import AboutUsView from '../views/aboutUs/AboutUsView';
+import ProfileView from '../views/profiles/ProfileView';
 
 const Drawer = createDrawerNavigator();
 
@@ -20,6 +21,7 @@ const DrawerNavigator = () => {
     >
       <Drawer.Screen name="BottomTabs" component={BottomTabNavigator} />
       <Drawer.Screen name="AboutUsView" component={AboutUsView} />
+      <Drawer.Screen name="ProfileView" component={ProfileView} />
     </Drawer.Navigator>
   )
 }

--- a/app/views/profiles/ProfileView.android.js
+++ b/app/views/profiles/ProfileView.android.js
@@ -10,6 +10,7 @@ const ProfileView = () => {
       header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក'/>}
       body={<ProfileMainComponent/>}
       scrollViewStyle={{paddingBottom: 0}}
+      scrollable={false}
     />
   )
 }

--- a/app/views/profiles/ProfileView.android.js
+++ b/app/views/profiles/ProfileView.android.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
+import NavigationHeaderWithBackButtonComponent from '../../components/shared/NavigationHeaderWithBackButtonComponent';
+import ProfileMainComponent from '../../components/profiles/ProfileMainComponent';
+
+const ProfileView = () => {
+  return (
+    <GradientScrollViewComponent
+      header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក'/>}
+      body={<ProfileMainComponent/>}
+      scrollViewStyle={{paddingBottom: 0}}
+    />
+  )
+}
+
+export default ProfileView;

--- a/app/views/profiles/ProfileView.android.js
+++ b/app/views/profiles/ProfileView.android.js
@@ -3,12 +3,19 @@ import React from 'react';
 import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
 import NavigationHeaderWithBackButtonComponent from '../../components/shared/NavigationHeaderWithBackButtonComponent';
 import ProfileMainComponent from '../../components/profiles/ProfileMainComponent';
+import {navigationRef} from '../../navigators/app_navigator';
 
 const ProfileView = () => {
+  const [playingUuid, setPlayingUuid] = React.useState(null);
+  const onBackPress = () => {
+    setPlayingUuid(null)
+    navigationRef.current?.goBack()
+  }
+
   return (
     <GradientScrollViewComponent
-      header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក'/>}
-      body={<ProfileMainComponent/>}
+      header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក' onPress={() => onBackPress()}/>}
+      body={<ProfileMainComponent playingUuid={playingUuid} updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}/>}
       scrollViewStyle={{paddingBottom: 0}}
       scrollable={false}
     />

--- a/app/views/profiles/ProfileView.ios.js
+++ b/app/views/profiles/ProfileView.ios.js
@@ -10,6 +10,7 @@ const ProfileView = () => {
       header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក'/>}
       body={<ProfileMainComponent/>}
       scrollViewStyle={{paddingBottom: 0}}
+      scrollable={false}
     />
   )
 }

--- a/app/views/profiles/ProfileView.ios.js
+++ b/app/views/profiles/ProfileView.ios.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
+import NavigationHeaderWithBackButtonComponent from '../../components/shared/NavigationHeaderWithBackButtonComponent';
+import ProfileMainComponent from '../../components/profiles/ProfileMainComponent';
+
+const ProfileView = () => {
+  return (
+    <GradientScrollViewComponent
+      header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក'/>}
+      body={<ProfileMainComponent/>}
+      scrollViewStyle={{paddingBottom: 0}}
+    />
+  )
+}
+
+export default ProfileView;

--- a/app/views/profiles/ProfileView.ios.js
+++ b/app/views/profiles/ProfileView.ios.js
@@ -3,12 +3,19 @@ import React from 'react';
 import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
 import NavigationHeaderWithBackButtonComponent from '../../components/shared/NavigationHeaderWithBackButtonComponent';
 import ProfileMainComponent from '../../components/profiles/ProfileMainComponent';
+import {navigationRef} from '../../navigators/app_navigator';
 
 const ProfileView = () => {
+  const [playingUuid, setPlayingUuid] = React.useState(null);
+  const onBackPress = () => {
+    setPlayingUuid(null)
+    navigationRef.current?.goBack()
+  }
+
   return (
     <GradientScrollViewComponent
-      header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក'/>}
-      body={<ProfileMainComponent/>}
+      header={<NavigationHeaderWithBackButtonComponent label='ព័ត៌មានរបស់អ្នក' onPress={() => onBackPress()}/>}
+      body={<ProfileMainComponent playingUuid={playingUuid} updatePlayingUuid={(uuid) => setPlayingUuid(uuid)}/>}
       scrollViewStyle={{paddingBottom: 0}}
       scrollable={false}
     />

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -215,8 +215,6 @@ PODS:
   - nanopb/encode (2.30909.0)
   - OpenSSL-Universal (1.1.1100)
   - PromisesObjC (2.1.1)
-  - PromisesSwift (2.1.1):
-    - PromisesObjC (= 2.1.1)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -465,12 +463,6 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-splash-screen (3.3.0):
     - React-Core
-  - react-native-video (6.0.0-alpha.3):
-    - React-Core
-    - react-native-video/Video (= 6.0.0-alpha.3)
-  - react-native-video/Video (6.0.0-alpha.3):
-    - PromisesSwift
-    - React-Core
   - react-native-webview (11.23.1):
     - React-Core
   - React-perflogger (0.70.3)
@@ -663,7 +655,6 @@ DEPENDENCIES:
   - react-native-render-html (from `../node_modules/react-native-render-html`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
-  - react-native-video (from `../node_modules/react-native-video`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -719,7 +710,6 @@ SPEC REPOS:
     - nanopb
     - OpenSSL-Universal
     - PromisesObjC
-    - PromisesSwift
     - Sentry
     - SocketRocket
     - YogaKit
@@ -785,8 +775,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-splash-screen:
     :path: "../node_modules/react-native-splash-screen"
-  react-native-video:
-    :path: "../node_modules/react-native-video"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-perflogger:
@@ -873,7 +861,6 @@ SPEC CHECKSUMS:
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  PromisesSwift: 99fddfe4a0ec88a56486644c0da106694c92a604
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: 5cf7e7d2f12699724b59f90350257a422eaa9492
   RCTTypeSafety: 3f3ead9673d1ab8bb1aea85b0894ab3220f8f06e
@@ -897,7 +884,6 @@ SPEC CHECKSUMS:
   react-native-render-html: 984dfe2294163d04bf5fe25d7c9f122e60e05ebe
   react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
-  react-native-video: 3b4fa3b67e6d8efcfba6c27231a7a493c28d4f1f
   react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
   React-perflogger: 082b4293f0b3914ff41da35a6c06ac4490fcbcc8
   React-RCTActionSheet: 83da3030deb5dea54b398129f56540a44e64d3ae


### PR DESCRIPTION
This pull request creates a new screen for rendering the user's profile and makes so enhancements to the navigation drawer as listed below:
- Remove "ចាប់ផ្ដើមសាជាថ្មី" from navigation drawer
- Change the location between "ចែករំលែកកម្មវិធី" with "អំពីកម្មវិធី" in the navigation drawer
- Add the chevron-right icon next to the user info to make it looks pressable

Below are the screenshots of the profile detail screen and the navigation drawer on iOS and Android devices:
[profile detail screen.zip](https://github.com/kawsangs/adolescents_app/files/10751888/profile.detail.screen.zip)


