### PR TITLE
Include device MODEL, OS, and OS version when send mobile token request

### DIFF
--- a/App.android.js
+++ b/App.android.js
@@ -68,7 +68,6 @@ const App: () => Node = () => {
 
   useEffect(() => {
     SplashScreen.hide();
-    MobileTokenService.handleSyncingToken();
     MobileTokenService.onNotificationOpenApp(() => navigationRef.current?.navigate('NotificationView'));
     seedDataService.seedToRealm();
     appVisitService.recordVisit();

--- a/App.ios.js
+++ b/App.ios.js
@@ -65,7 +65,6 @@ const App: () => Node = () => {
 
   useEffect(() => {
     SplashScreen.hide();
-    MobileTokenService.handleSyncingToken();
     MobileTokenService.onNotificationOpenApp(() => navigationRef.current?.navigate('NotificationView'));
     seedDataService.seedToRealm();
     appVisitService.recordVisit();

--- a/app/constants/async_storage_constant.js
+++ b/app/constants/async_storage_constant.js
@@ -3,3 +3,5 @@ export const AUTH_TOKEN = 'AUTH_TOKEN';
 export const APP_USER = 'APP_USER';
 export const USER_INFO_CHANGED = 'USER_INFO_CHANGED';
 export const TEXT_SIZE = 'TEXT_SIZE';
+export const TOKEN_SYNCED = 'TOKEN_SYNCED';
+export const REGISTERED_TOKEN = 'registeredToken';

--- a/app/services/mobile_token_service.js
+++ b/app/services/mobile_token_service.js
@@ -129,14 +129,22 @@ const MobileTokenService = (() => {
         device_type: DeviceInfo.isTablet() ? 'tablet' : 'mobile',
         app_version: DeviceInfo.getVersion(),
         platform: Platform.OS,
+        device_os: `${DeviceInfo.getSystemName()}_${DeviceInfo.getSystemVersion()}`
       }
     };
 
-    Api.post(Api.listingUrl(), data, function(res) {
-      AsyncStorageService.setItem(TOKEN_KEY, res);
-    });
+    DeviceInfo.getManufacturer().then((manufacturer) => {
+      data['mobile_token']['device_os'] = `${manufacturer}_${DeviceInfo.getSystemName()}_${DeviceInfo.getSystemVersion()}`
+      Api.post(Api.listingUrl(), data, function(res) {
+        AsyncStorageService.setItem(TOKEN_KEY, res);
+      });
+    })
+    .catch((error) => {
+      Api.post(Api.listingUrl(), data, function(res) {
+        AsyncStorageService.setItem(TOKEN_KEY, res);
+      });
+    })
   }
-
 })();
 
 export default MobileTokenService;

--- a/app/views/home/HomeView.android.js
+++ b/app/views/home/HomeView.android.js
@@ -9,6 +9,7 @@ import CardListComponent from '../../components/shared/CardListComponent';
 import syncService from '../../services/sync_service';
 import Category from '../../models/Category';
 import audioPlayerService from '../../services/audio_player_service';
+import MobileTokenService from '../../services/mobile_token_service';
 
 const HomeView = (props) => {
   const [playingUuid, setPlayingUuid] = useState(null);
@@ -17,8 +18,10 @@ const HomeView = (props) => {
   useEffect(() => {
     let previousStatus = false;  // we store the previousStatus in order to prevent the syncUsers from calling twice when has internet connection
     const unsubscribeNetInfo = NetInfo.addEventListener((state) => {
-      if (state.isConnected && state.isInternetReachable != previousStatus && state.isInternetReachable)
+      if (state.isConnected && state.isInternetReachable != previousStatus && state.isInternetReachable) {
         syncService.syncUsersAndVisits();
+        MobileTokenService.handleSyncingToken();
+      }
 
       if (previousStatus != state.isInternetReachable) previousStatus = state.isInternetReachable;
     });

--- a/app/views/home/HomeView.ios.js
+++ b/app/views/home/HomeView.ios.js
@@ -8,6 +8,7 @@ import CardListComponent from '../../components/shared/CardListComponent';
 import syncService from '../../services/sync_service';
 import Category from '../../models/Category';
 import audioPlayerService from '../../services/audio_player_service';
+import MobileTokenService from '../../services/mobile_token_service';
 import {gradientScrollViewBigPaddingBottom} from '../../constants/ios_component_constant';
 
 const HomeView = (props) => {
@@ -17,8 +18,10 @@ const HomeView = (props) => {
   useEffect(() => {
     let previousStatus = false;  // we store the previousStatus in order to prevent the syncUsers from calling twice when has internet connection
     const unsubscribeNetInfo = NetInfo.addEventListener((state) => {
-      if (state.isConnected && state.isInternetReachable != previousStatus && state.isInternetReachable)
+      if (state.isConnected && state.isInternetReachable != previousStatus && state.isInternetReachable) {
         syncService.syncUsersAndVisits();
+        MobileTokenService.handleSyncingToken();
+      }
 
       if (previousStatus != state.isInternetReachable) previousStatus = state.isInternetReachable;
     });


### PR DESCRIPTION
This pull request adds the device's model, OS, and OS version when sending a mobile token request. And send the token request when the user is focused on the home screen with the internet connection available.

** NOTICE:
- If it is able to get the device's manufacturer the device_os will look like this: samsung_Android_10
- If it is not able to the device's manufacturer the device_os will look like this: Android_10