### PR TITLE
Decrease font size and increase register consent bottom sheet to solv…

### DIFF
--- a/app/assets/stylesheets/mobile/policyConfirmationModalComponentStyles.js
+++ b/app/assets/stylesheets/mobile/policyConfirmationModalComponentStyles.js
@@ -17,7 +17,7 @@ const policyConfirmationModalComponentStyles = StyleSheet.create({
     width: 38
   },
   instruction: {
-    fontSize: itemFontSize,
+    fontSize: Platform.OS == 'ios' ? largeFontSize() : largeFontSize() + 0.5,
     lineHeight: 30
   },
   titleContainer: {

--- a/app/constants/modal_constant.js
+++ b/app/constants/modal_constant.js
@@ -10,9 +10,9 @@ export const contactContentHeight = getStyleOfDevice('27%', '37.5%');
 export const servicesSnapPoints = ['38%'];
 export const servicesContentHeight = '33%';
 
-const confirmationiOSMobie = DeviceInfo.hasNotch() ? {snapPoints: ['46%'], height: '43%'} : isLowPixelDensityDevice() ? {snapPoints: ['53%'], height: '57%'} : {snapPoints: ['50%'], height: '44%'}
-const confirmationAndroidMobile = isLowPixelDensityDevice() ? {snapPoints: ['54%'], height: '48%'} : {snapPoints: ['50%'], height: '44%'}
-export const signUpConfirmationSnapPoints = Platform.OS == 'ios' ? getStyleOfDevice(['32%'], confirmationiOSMobie.snapPoints) : getStyleOfDevice(['41%'], confirmationAndroidMobile.snapPoints);
-export const signUpConfirmationContentHeight = Platform.OS == 'ios' ? getStyleOfDevice('25%', confirmationiOSMobie.height) : getStyleOfDevice('36%', confirmationAndroidMobile.height);
+const confirmationiOSMobile = DeviceInfo.hasNotch() ? {snapPoints: ['46%'], height: '43%'} : isLowPixelDensityDevice() ? {snapPoints: ['53%'], height: '57%'} : {snapPoints: ['50%'], height: '44%'}
+const confirmationAndroidMobile = isLowPixelDensityDevice() ? {snapPoints: ['56%'], height: '50%'} : {snapPoints: ['52%'], height: '46%'}
+export const signUpConfirmationSnapPoints = Platform.OS == 'ios' ? getStyleOfDevice(['32%'], confirmationiOSMobile.snapPoints) : getStyleOfDevice(['41%'], confirmationAndroidMobile.snapPoints);
+export const signUpConfirmationContentHeight = Platform.OS == 'ios' ? getStyleOfDevice('25%', confirmationiOSMobile.height) : getStyleOfDevice('36%', confirmationAndroidMobile.height);
 export const videoFilterSnapPoints = getStyleOfDevice(['52%'], ['65%']);
 export const videoFilterContentHeight = getStyleOfDevice(hp('47%'), hp('60%'));


### PR DESCRIPTION
This pull request decreases the font size and increases the height of the registration consent bottom sheet to solve the style issue on some Android devices.

Below are the screenshots of the Android devices with different screen sizes and resolutions:
[Adolescent login consent bottom sheet.zip](https://github.com/kawsangs/adolescents_app/files/12065866/Adolescent.login.consent.bottom.sheet.zip)

