### PR TITLE
Add education level to registration screen

### DIFF
--- a/app/assets/stylesheets/mobile/profileInfoListItemComponentStyles.js
+++ b/app/assets/stylesheets/mobile/profileInfoListItemComponentStyles.js
@@ -1,4 +1,4 @@
-import {StyleSheet} from 'react-native';
+import {StyleSheet, Platform} from 'react-native';
 import {descriptionFontSize} from '../../../constants/component_constant';
 
 const profileInfoComponentStyles = StyleSheet.create({
@@ -10,7 +10,12 @@ const profileInfoComponentStyles = StyleSheet.create({
   infoWrapper: {
     alignItems: 'center',
     flex: 10,
-    flexDirection: 'row'
+    flexDirection: 'row',
+    ...Platform.select({
+      ios: {
+        paddingTop: 3
+      }
+    })
   },
   label: {
     fontSize: descriptionFontSize,
@@ -21,7 +26,12 @@ const profileInfoComponentStyles = StyleSheet.create({
     alignItems: 'center',
     flex: 6,
     flexDirection: 'row',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    ...Platform.select({
+      ios: {
+        paddingTop: 3
+      }
+    })
   },
   valueLabel: {
     fontSize: descriptionFontSize,

--- a/app/assets/stylesheets/tablet/profileInfoListItemComponentStyles.js
+++ b/app/assets/stylesheets/tablet/profileInfoListItemComponentStyles.js
@@ -10,7 +10,12 @@ const profileInfoComponentStyles = StyleSheet.create({
   infoWrapper: {
     alignItems: 'center',
     flex: 10,
-    flexDirection: 'row'
+    flexDirection: 'row',
+    ...Platform.select({
+      ios: {
+        paddingTop: 3
+      }
+    })
   },
   label: {
     fontSize: descriptionFontSize,
@@ -21,7 +26,12 @@ const profileInfoComponentStyles = StyleSheet.create({
     alignItems: 'center',
     flex: 6,
     flexDirection: 'row',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    ...Platform.select({
+      ios: {
+        paddingTop: 3
+      }
+    })
   },
   valueLabel: {
     fontSize: descriptionFontSize,

--- a/app/components/createAccounts/CreateAccountFormComponent.android.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.android.js
@@ -18,6 +18,7 @@ const CreateAccountFormComponent = (props) => {
     province: null,
     characteristics: [],
     occupation: null,
+    educationLevel: null,
   });
   const [isValid, setIsValid] = useState(false);
   const [playingUuid, setPlayingUuid] = useState(null);
@@ -36,6 +37,7 @@ const CreateAccountFormComponent = (props) => {
               age={state.age}
               province={state.province}
               occupation={state.occupation}
+              educationLevel={state.educationLevel}
               characteristics={state.characteristics}
               updateState={(fieldName, value) => updateState(fieldName, value)}
               playingUuid={playingUuid}

--- a/app/components/createAccounts/CreateAccountFormComponent.android.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.android.js
@@ -17,10 +17,8 @@ const CreateAccountFormComponent = (props) => {
     age: 0,
     province: null,
     characteristics: [],
-    // occupation: null,
-    // educationLevel: null,
-    occupation: 'n_a',
-    educationLevel: 'n_a',
+    occupation: null,
+    educationLevel: null,
   });
   const [isValid, setIsValid] = useState(false);
   const [playingUuid, setPlayingUuid] = useState(null);

--- a/app/components/createAccounts/CreateAccountFormComponent.android.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.android.js
@@ -28,7 +28,7 @@ const CreateAccountFormComponent = (props) => {
     const newState = state;
     newState[fieldName] = value;
     setState({...newState});
-    setIsValid(appUserService.isValidForm(state.age, state.province, state.occupation));
+    setIsValid(appUserService.isValidForm(state.age, state.province, state.occupation, state.educationLevel));
     asyncStorageService.setItem(USER_INFO_CHANGED, true);
   }
 

--- a/app/components/createAccounts/CreateAccountFormComponent.android.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.android.js
@@ -17,8 +17,10 @@ const CreateAccountFormComponent = (props) => {
     age: 0,
     province: null,
     characteristics: [],
-    occupation: null,
-    educationLevel: null,
+    // occupation: null,
+    // educationLevel: null,
+    occupation: 'n_a',
+    educationLevel: 'n_a',
   });
   const [isValid, setIsValid] = useState(false);
   const [playingUuid, setPlayingUuid] = useState(null);

--- a/app/components/createAccounts/CreateAccountFormComponent.android.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.android.js
@@ -51,7 +51,8 @@ const CreateAccountFormComponent = (props) => {
       age: parseInt(state.age),
       province_id: state.province,
       characteristics: state.characteristics,
-      occupation: state.occupation
+      occupation: state.occupation,
+      education_level: state.educationLevel
     }
 
     appUserService.createUser(user);

--- a/app/components/createAccounts/CreateAccountFormComponent.ios.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.ios.js
@@ -18,6 +18,7 @@ const CreateAccountFormComponent = (props) => {
     province: null,
     characteristics: [],
     occupation: null,
+    educationLevel: null,
   });
   const [isValid, setIsValid] = useState(false);
   const [playingUuid, setPlayingUuid] = useState(null);
@@ -27,7 +28,7 @@ const CreateAccountFormComponent = (props) => {
     const newState = state;
     newState[fieldName] = value;
     setState({...newState});
-    setIsValid(appUserService.isValidForm(state.age, state.province, state.occupation));
+    setIsValid(appUserService.isValidForm(state.age, state.province, state.occupation, state.educationLevel));
     asyncStorageService.setItem(USER_INFO_CHANGED, true);
   }
 
@@ -36,6 +37,7 @@ const CreateAccountFormComponent = (props) => {
               age={state.age}
               province={state.province}
               occupation={state.occupation}
+              educationLevel={state.educationLevel}
               characteristics={state.characteristics}
               updateState={(fieldName, value) => updateState(fieldName, value)}
               playingUuid={playingUuid}

--- a/app/components/createAccounts/CreateAccountFormComponent.ios.js
+++ b/app/components/createAccounts/CreateAccountFormComponent.ios.js
@@ -51,7 +51,8 @@ const CreateAccountFormComponent = (props) => {
       age: parseInt(state.age),
       province_id: state.province,
       characteristics: state.characteristics,
-      occupation: state.occupation
+      occupation: state.occupation,
+      education_level: state.educationLevel
     }
     appUserService.createUser(user);
     dispatch(setLoginUserOccupation(state.occupation));

--- a/app/components/createAccounts/CreateAccountSelectionsComponent.android.js
+++ b/app/components/createAccounts/CreateAccountSelectionsComponent.android.js
@@ -11,7 +11,6 @@ import {
   androidEducationLevelContentHeight, androidEducationLevelSnapPoints
 } from '../../constants/modal_constant';
 import color from '../../themes/color';
-import {isShortScreenDevice} from '../../utils/responsive_util';
 
 const CreateAccountSelectionsComponent = (props) => {
   const {t, i18n} = useTranslation();
@@ -54,6 +53,12 @@ const CreateAccountSelectionsComponent = (props) => {
            />
   }
 
+  const onOccupationChange = (occupation) => {
+    props.updateState('occupation', occupation)
+    if (occupation == 'student' && props.educationLevel == 'dropout_student')
+      props.updateState('educationLevel', null);
+  }
+
   const renderOccupationPicker = () => {
     return <CustomBottomSheetPickerComponent
               title='មុខរបរ'
@@ -63,7 +68,7 @@ const CreateAccountSelectionsComponent = (props) => {
               requiredColor={color.blackColor}
               items={userHelper.getOccupationDataset(i18n.language)}
               selectedItem={props.occupation}
-              onSelectItem={(item) => props.updateState('occupation', item)}
+              onSelectItem={(item) => onOccupationChange(item)}
               pickerUuid='user-occupation-picker'
               placeholderAudio={null}
               playingUuid={props.playingUuid}
@@ -85,7 +90,7 @@ const CreateAccountSelectionsComponent = (props) => {
               bottomSheetTitle="កម្រិតវប្បធម៌"
               required={true}
               requiredColor={color.blackColor}
-              items={userHelper.getEducationDataset(i18n.language)}
+              items={userHelper.getEducationDataset(i18n.language, props.occupation)}
               selectedItem={props.educationLevel}
               onSelectItem={(item) => props.updateState('educationLevel', item)}
               pickerUuid='user-education-picker'
@@ -99,6 +104,7 @@ const CreateAccountSelectionsComponent = (props) => {
               subtitleStyle={{marginTop: 0}}
               itemTextStyle={{marginTop: -2}}
               listItemStyle={{paddingTop: 0}}
+              disabled={!props.occupation}
            />
   }
 

--- a/app/components/createAccounts/CreateAccountSelectionsComponent.android.js
+++ b/app/components/createAccounts/CreateAccountSelectionsComponent.android.js
@@ -6,7 +6,10 @@ import CustomBottomSheetPickerComponent from '../shared/CustomBottomSheetPickerC
 import characteristics from '../../db/data/characteristics';
 import userHelper from '../../helpers/user_helper';
 import audioSources from '../../constants/audio_source_constant';
-import { androidOccupationContentHeight, androidOccupationSnapPoints } from '../../constants/modal_constant';
+import {
+  androidOccupationContentHeight, androidOccupationSnapPoints,
+  androidEducationLevelContentHeight, androidEducationLevelSnapPoints
+} from '../../constants/modal_constant';
 import color from '../../themes/color';
 import {isShortScreenDevice} from '../../utils/responsive_util';
 
@@ -53,9 +56,9 @@ const CreateAccountSelectionsComponent = (props) => {
 
   const renderOccupationPicker = () => {
     return <CustomBottomSheetPickerComponent
-              title={t('occupation')}
-              placeholder={t('selectYourOccupation')}
-              bottomSheetTitle={t('yourOccupaton')}
+              title='មុខរបរ'
+              placeholder='ជ្រើសរើសមុខរបរ'
+              bottomSheetTitle='មុខរបរ'
               required={true}
               requiredColor={color.blackColor}
               items={userHelper.getOccupationDataset(i18n.language)}
@@ -75,10 +78,35 @@ const CreateAccountSelectionsComponent = (props) => {
            />
   }
 
+  const renderEducationLevelPicker = () => {
+    return <CustomBottomSheetPickerComponent
+              title="កម្រិតវប្បធម៌"
+              placeholder="ជ្រើសរើសកម្រិតវប្បធម៌"
+              bottomSheetTitle="កម្រិតវប្បធម៌"
+              required={true}
+              requiredColor={color.blackColor}
+              items={userHelper.getEducationDataset(i18n.language)}
+              selectedItem={props.educationLevel}
+              onSelectItem={(item) => props.updateState('educationLevel', item)}
+              pickerUuid='user-education-picker'
+              placeholderAudio={null}
+              playingUuid={props.playingUuid}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+              containerStyle={{marginTop: sectionMarginTop}}
+              snapPoints={androidEducationLevelSnapPoints}
+              pickerContentHeight={androidEducationLevelContentHeight}
+              showSubtitle={true}
+              subtitleStyle={{marginTop: 0}}
+              itemTextStyle={{marginTop: -2}}
+              listItemStyle={{paddingTop: 0}}
+           />
+  }
+
   return <React.Fragment>
             { renderAgePicker() }
             { renderProvincePicker() }
             { renderOccupationPicker() }
+            { renderEducationLevelPicker() }
             <CheckboxComponent items={characteristics} title={t('yourCharacteristic')}
               selectedItems={props.characteristics}
               style={{marginTop: sectionMarginTop}}

--- a/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
+++ b/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
@@ -6,7 +6,10 @@ import CustomBottomSheetPickerComponent from '../shared/CustomBottomSheetPickerC
 import characteristics from '../../db/data/characteristics';
 import userHelper from '../../helpers/user_helper';
 import audioSources from '../../constants/audio_source_constant';
-import {iosOccupationContentHeight, iosOccupationSnapPoints} from '../../constants/modal_constant';
+import {
+  iosOccupationContentHeight, iosOccupationSnapPoints,
+  iosEducationLevelContentHeight, iosEducationLevelSnapPoints
+} from '../../constants/modal_constant';
 import color from '../../themes/color';
 
 const CreateAccountSelectionsComponent = (props) => {
@@ -50,6 +53,12 @@ const CreateAccountSelectionsComponent = (props) => {
            />
   }
 
+  const onOccupationChange = (occupation) => {
+    props.updateState('occupation', occupation)
+    if (occupation == 'student' && props.educationLevel == 'dropout_student')
+      props.updateState('educationLevel', null);
+  }
+
   const renderOccupationPicker = () => {
     return <CustomBottomSheetPickerComponent
               title='មុខរបរ'
@@ -59,7 +68,7 @@ const CreateAccountSelectionsComponent = (props) => {
               requiredColor={color.blackColor}
               items={userHelper.getOccupationDataset(i18n.language)}
               selectedItem={props.occupation}
-              onSelectItem={(item) => props.updateState('occupation', item)}
+              onSelectItem={(item) => onOccupationChange(item)}
               pickerUuid='user-occupation-picker'
               placeholderAudio={null}
               playingUuid={props.playingUuid}
@@ -71,10 +80,36 @@ const CreateAccountSelectionsComponent = (props) => {
            />
   }
 
+  const renderEducationLevelPicker = () => {
+    return <CustomBottomSheetPickerComponent
+              title="កម្រិតវប្បធម៌"
+              placeholder="ជ្រើសរើសកម្រិតវប្បធម៌"
+              bottomSheetTitle="កម្រិតវប្បធម៌"
+              required={true}
+              requiredColor={color.blackColor}
+              items={userHelper.getEducationDataset(i18n.language, props.occupation)}
+              selectedItem={props.educationLevel}
+              onSelectItem={(item) => props.updateState('educationLevel', item)}
+              pickerUuid='user-education-picker'
+              placeholderAudio={null}
+              playingUuid={props.playingUuid}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+              containerStyle={{marginTop: sectionMarginTop}}
+              snapPoints={iosEducationLevelSnapPoints}
+              pickerContentHeight={iosEducationLevelContentHeight}
+              showSubtitle={true}
+              subtitleStyle={{marginTop: 0}}
+              itemTextStyle={{marginTop: -2}}
+              listItemStyle={{paddingTop: 0}}
+              disabled={!props.occupation}
+           />
+  }
+
   return <React.Fragment>
             { renderAgePicker() }
             { renderProvincePicker() }
             { renderOccupationPicker() }
+            { renderEducationLevelPicker() }
             <CheckboxComponent items={characteristics} title={t('yourCharacteristic')}
               selectedItems={props.characteristics}
               style={{marginTop: sectionMarginTop}}

--- a/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
+++ b/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
@@ -52,9 +52,9 @@ const CreateAccountSelectionsComponent = (props) => {
 
   const renderOccupationPicker = () => {
     return <CustomBottomSheetPickerComponent
-              title={t('occupation')}
-              placeholder={t('selectYourOccupation')}
-              bottomSheetTitle={t('yourOccupaton')}
+              title='មុខរបរ'
+              placeholder='ជ្រើសរើសមុខរបរ'
+              bottomSheetTitle='មុខរបរ'
               required={true}
               requiredColor={color.blackColor}
               items={userHelper.getOccupationDataset(i18n.language)}

--- a/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
+++ b/app/components/createAccounts/CreateAccountSelectionsComponent.ios.js
@@ -77,6 +77,8 @@ const CreateAccountSelectionsComponent = (props) => {
               snapPoints={iosOccupationSnapPoints}
               pickerContentHeight={iosOccupationContentHeight}
               showSubtitle={true}
+              itemTextStyle={{marginTop: -4}}
+              listItemStyle={{paddingTop: 0}}
            />
   }
 
@@ -98,8 +100,7 @@ const CreateAccountSelectionsComponent = (props) => {
               snapPoints={iosEducationLevelSnapPoints}
               pickerContentHeight={iosEducationLevelContentHeight}
               showSubtitle={true}
-              subtitleStyle={{marginTop: 0}}
-              itemTextStyle={{marginTop: -2}}
+              itemTextStyle={{marginTop: -4}}
               listItemStyle={{paddingTop: 0}}
               disabled={!props.occupation}
            />

--- a/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.android.js
+++ b/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.android.js
@@ -40,7 +40,7 @@ const DrawerNavigatorHeaderComponent = (props) => {
         </Text>
         <FeatherIcon name="chevron-right" color={color.whiteColor} size={22} style={{marginLeft: 10, marginTop: -2}} />
 
-        { userOccupation == 'n_a' && <NoticeBadgeComponent style={{width: 16, height: 16, top: -10, right: -4}}/> }
+        { (!User.isLoginAsAnonymous() && userOccupation == 'n_a') && <NoticeBadgeComponent style={{width: 16, height: 16, top: -10, right: -4}}/> }
       </View>
     </TouchableOpacity>
   )

--- a/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
+++ b/app/components/drawerNavigators/DrawerNavigatorHeaderComponent.ios.js
@@ -40,7 +40,7 @@ const DrawerNavigatorHeaderComponent = (props) => {
         </Text>
         <FeatherIcon name="chevron-right" color={color.whiteColor} size={22} style={{marginLeft: 10, marginTop: 2}} />
 
-        { userOccupation == 'n_a' && <NoticeBadgeComponent style={{width: 16, height: 16, top: -10, right: -4}}/> }
+        { (!User.isLoginAsAnonymous() && userOccupation == 'n_a') && <NoticeBadgeComponent style={{width: 16, height: 16, top: -10, right: -4}}/> }
       </View>
     </TouchableOpacity>
   )

--- a/app/components/profiles/ProfileCharacteristicsComponent.ios.js
+++ b/app/components/profiles/ProfileCharacteristicsComponent.ios.js
@@ -34,7 +34,7 @@ const ProfileCharacteristicsComponent = (props) => {
   }
 
   return <React.Fragment>
-            <Text style={{fontSize: descriptionFontSize, marginBottom: 6, marginTop: 18}}>ស្ថានភាពរស់នៅ</Text>
+            <Text style={{fontSize: descriptionFontSize, marginBottom: 6, marginTop: getStyleOfDevice(10, 18)}}>ស្ថានភាពរស់នៅ</Text>
             {renderItems()}
           </React.Fragment>
 }

--- a/app/components/profiles/ProfileCharacteristicsComponent.ios.js
+++ b/app/components/profiles/ProfileCharacteristicsComponent.ios.js
@@ -34,7 +34,7 @@ const ProfileCharacteristicsComponent = (props) => {
   }
 
   return <React.Fragment>
-            <Text style={{fontSize: descriptionFontSize, marginBottom: 6, marginTop: 6}}>ស្ថានភាពរស់នៅ</Text>
+            <Text style={{fontSize: descriptionFontSize, marginBottom: 6, marginTop: 18}}>ស្ថានភាពរស់នៅ</Text>
             {renderItems()}
           </React.Fragment>
 }

--- a/app/components/profiles/ProfileInfoComponent.ios.js
+++ b/app/components/profiles/ProfileInfoComponent.ios.js
@@ -5,14 +5,19 @@ import FeatherIcon from 'react-native-vector-icons/Feather';
 
 import ProfileCharacteristicsComponent from './ProfileCharacteristicsComponent';
 import ProfileInfoListItemComponent from './ProfileInfoListItemComponent';
-import ProfileInfoOccupationItemComponent from './ProfileInfoOccupationItemComponent';
+import ProfileInfoItemWithPickerComponent from './ProfileInfoItemWithPickerComponent';
 import AnonymousIconComponent from '../shared/AnonymousIconComponent';
 import GradientViewComponent from '../shared/GradientViewComponent';
 import {cardBorderRadius, cardElevation} from '../../constants/component_constant';
 import {anonymousInfo} from '../../constants/user_constant';
+import {
+  androidOccupationContentHeight, androidOccupationSnapPoints,
+  androidEducationLevelSnapPoints, androidEducationLevelContentHeight
+} from '../../constants/modal_constant';
 import User from '../../models/User';
 import translationHelper from '../../helpers/translation_helper';
 import profileHelper from '../../helpers/profile_helper';
+import userHelper from '../../helpers/user_helper';
 import {getStyleOfDevice} from '../../utils/responsive_util';
 import color from '../../themes/color';
 
@@ -43,24 +48,57 @@ const ProfileInfoComponent = (props) => {
         audio: province.audio,
       }
     ]
-    return infos.map((info, index) => {
+    const nonPickerComponents = infos.map((info, index) => {
      return <ProfileInfoListItemComponent key={info.uuid} info={info} gender={gender} playingUuid={props.playingUuid} hasIcon={index == 0}
               updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
             />
     })
+    return <React.Fragment>
+              { nonPickerComponents }
+              { renderOccupation() }
+              { renderEducationLevel() }
+           </React.Fragment>
+  }
+
+  onOccupationChange = (occupation) => {
+    props.updateOccupation(occupation)
+    if (occupation == 'student' && props.educationLevel == 'dropout_student')
+      props.updateEducationLevel('n_a');
   }
 
   renderOccupation = () => {
     const info = {
-      value: (!!props.selectedOccupation && props.selectedOccupation != 'n_a') ? profileHelper.getOccupation(props.selectedOccupation).name_km : null,
-      audio: (!!props.selectedOccupation && props.selectedOccupation != 'n_a') ? profileHelper.getOccupation(props.selectedOccupation).audio : null,
+      value: props.occupation != 'n_a' ? profileHelper.getOccupation(props.occupation).name_km : null,
+      audio: props.occupation != 'n_a' ? profileHelper.getOccupation(props.occupation).audio : null,
     }
-    return <ProfileInfoOccupationItemComponent key='user-occupation' info={info} playingUuid={props.playingUuid}
+    return <ProfileInfoItemWithPickerComponent uuid='user-occupation-picker' info={info} playingUuid={props.playingUuid}
+              label='មុខរបរ' bottomSheetTitle='មុខរបរ' pickerLabel='ជ្រើសរើសមុខរបរ'
+              items={userHelper.getOccupationDataset(i18n.language)}
+              selectedValue={props.occupation}
+              isPickerVisible={loggedInUser.occupation == 'n_a'}
+              snapPoints={androidOccupationSnapPoints}
+              contentHeight={androidOccupationContentHeight}
               updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
-              updateOccupation={(value) => props.updateSelectedOccupation(value)}
-              loggedInUser={loggedInUser}
-              selectedValue={props.selectedOccupation}
-            />
+              updateSelectedItem={(value) => onOccupationChange(value)}
+           />
+  }
+
+  renderEducationLevel = () => {
+    let info = { value: null, audio: null }
+    if (props.educationLevel != 'n_a' && props.occupation != 'n_a')
+      info = { value: profileHelper.getEducation(props.educationLevel).name_km, audio: profileHelper.getEducation(props.educationLevel).audio }
+
+    return <ProfileInfoItemWithPickerComponent uuid='user-education-picker' info={info} playingUuid={props.playingUuid}
+              label='កម្រិតវប្បធម៌' bottomSheetTitle='កម្រិតវប្បធម៌' pickerLabel='ជ្រើសរើសកម្រិតវប្បធម៌'
+              disabled={props.occupation == 'n_a'}
+              items={userHelper.getEducationDataset(i18n.language, props.occupation)}
+              selectedValue={props.educationLevel}
+              isPickerVisible={loggedInUser.education_level == 'n_a'}
+              snapPoints={androidEducationLevelSnapPoints}
+              contentHeight={androidEducationLevelContentHeight}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+              updateSelectedItem={(value) => props.updateEducationLevel(value)}
+           />
   }
 
   renderAnonymousInfo = () => {
@@ -88,7 +126,6 @@ const ProfileInfoComponent = (props) => {
         style={{borderRadius: cardBorderRadius, marginTop: 46, paddingLeft: 16, paddingBottom: paddingBottom, paddingTop: 36, marginBottom: 12}}
       >
         { !loggedInUser.anonymous ? renderInfo() : renderAnonymousInfo()}
-        { renderOccupation() }
         { loggedInUser.characteristics.length > 0 &&
           <ProfileCharacteristicsComponent
             playingUuid={props.playingUuid}

--- a/app/components/profiles/ProfileInfoItemWithPickerComponent.android.js
+++ b/app/components/profiles/ProfileInfoItemWithPickerComponent.android.js
@@ -2,48 +2,44 @@ import React from 'react';
 import {View} from 'react-native';
 import {Text} from 'react-native-paper';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import {useTranslation} from 'react-i18next';
 
 import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
 import CustomBottomSheetPickerComponent from '../shared/CustomBottomSheetPickerComponent';
 import NoticeBadgeComponent from '../shared/NoticeBadgeComponent';
 import color from '../../themes/color';
-import userHelper from '../../helpers/user_helper';
-import { androidOccupationContentHeight, androidOccupationSnapPoints } from '../../constants/modal_constant';
 import {getStyleOfDevice} from '../../utils/responsive_util';
 import tabletStyles from '../../assets/stylesheets/tablet/profileInfoListItemComponentStyles';
 import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemComponentStyles';
 
 const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 
-const ProfileInfoOccupationItemComponent = (props) => {
-  const {t, i18n} = useTranslation();
-  const {info, gender, playingUuid} = props;
+const ProfileInfoItemWithPickerComponent = (props) => {
+  const {info, playingUuid} = props;
 
-  const renderCustomPicker = () => {
+  const renderPickerLabel = () => {
     return <View style={{flexDirection: 'row', alignItems: 'center', height: '100%', marginTop: -3}}>
               {!info.value && <NoticeBadgeComponent style={{position: 'relative', width: 16, height: 16, marginRight: 6}} disableFixPosition={true}/>}
-              <Text style={[styles.valueLabel, {color: color.primaryColor, marginRight: 4}]}>
-                { !info.value ? 'ជ្រើសរើសមុខរបររបស់អ្នក' : info.value }
+              <Text style={[styles.valueLabel, {color: props.disabled ? color.disabledColor : color.primaryColor, marginRight: 4}]}>
+                { !info.value ? props.pickerLabel : info.value }
               </Text>
-              <Icon name='pencil-outline' size={22} color={color.primaryColor} />
+              <Icon name='pencil-outline' size={22} color={props.disabled ? color.disabledColor : color.primaryColor} />
            </View>
   }
 
-  const renderOccupationPicker = () => {
+  const renderCustomPicker = () => {
     return <CustomBottomSheetPickerComponent
-              bottomSheetTitle={t('yourOccupaton')}
-              items={userHelper.getOccupationDataset(i18n.language)}
+              bottomSheetTitle={props.bottomSheetTitle}
+              items={props.items}
               selectedItem={props.selectedValue}
-              onSelectItem={(item) => props.updateOccupation(item)}
-              pickerUuid='user-occupation-picker'
-              placeholderAudio={null}
+              onSelectItem={(item) => props.updateSelectedItem(item)}
+              pickerUuid={props.uuid}
+              placeholderAudio={props.placeholderAudio}
               playingUuid={playingUuid}
               updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
               containerStyle={[styles.valueWrapper, {flex: 8}]}
-              snapPoints={androidOccupationSnapPoints}
-              pickerContentHeight={androidOccupationContentHeight}
-              customPicker={renderCustomPicker()}
+              snapPoints={props.snapPoints}
+              pickerContentHeight={props.contentHeight}
+              customPicker={renderPickerLabel()}
               showSubtitle={true}
               subtitleStyle={{marginTop: 0}}
               itemTextStyle={{marginTop: -2}}
@@ -51,24 +47,25 @@ const ProfileInfoOccupationItemComponent = (props) => {
            />
   }
 
-  const renderOccupation = () => {
+  const renderPicker = () => {
     return <React.Fragment>
-              <View style={styles.infoWrapper}>
-                <Text style={[styles.label, {flex: 3}]}>មុខរបរ</Text>
-                {renderOccupationPicker()}
+              <View style={[styles.infoWrapper, props.disabled && {height: 62}]}>
+                <Text style={[styles.label, {flex: 3}]}>{props.label}</Text>
+                { props.disabled ? <View style={[styles.valueWrapper, {flex: 8}]}>{renderPickerLabel()}</View>
+                  : renderCustomPicker()
+                }
               </View>
             </React.Fragment>
   }
 
   const renderContent = () => {
-    if (props.loggedInUser.occupation == 'n_a')
-      return renderOccupation();
+    if (props.isPickerVisible)
+      return renderPicker();
 
     return <React.Fragment>
             <View style={styles.infoWrapper}>
               <Text style={[styles.label, {flex: 3}]}>មុខរបរ</Text>
               <View style={[styles.valueWrapper, {flex: 8}]}>
-                {props.hasIcon && <Icon name={gender.icon} size={30} style={{marginRight: 8}} color={color.lightBlackColor} />}
                 <Text style={styles.valueLabel}>{info.value}</Text>
               </View>
             </View>
@@ -76,7 +73,7 @@ const ProfileInfoOccupationItemComponent = (props) => {
               { !!info.audio &&
                 <CustomAudioPlayerButtonComponent
                   audio={info.audio}
-                  itemUuid='user-occupation'
+                  itemUuid={props.uuid}
                   playingUuid={playingUuid}
                   updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
                 />
@@ -85,10 +82,9 @@ const ProfileInfoOccupationItemComponent = (props) => {
           </React.Fragment>
   }
 
-
   return <View style={[styles.container, props.containerStyle]}>
             {renderContent()}
          </View>
 }
 
-export default ProfileInfoOccupationItemComponent;
+export default ProfileInfoItemWithPickerComponent;

--- a/app/components/profiles/ProfileInfoItemWithPickerComponent.android.js
+++ b/app/components/profiles/ProfileInfoItemWithPickerComponent.android.js
@@ -64,7 +64,7 @@ const ProfileInfoItemWithPickerComponent = (props) => {
 
     return <React.Fragment>
             <View style={styles.infoWrapper}>
-              <Text style={[styles.label, {flex: 3}]}>មុខរបរ</Text>
+              <Text style={[styles.label, {flex: 3}]}>{props.label}</Text>
               <View style={[styles.valueWrapper, {flex: 8}]}>
                 <Text style={styles.valueLabel}>{info.value}</Text>
               </View>

--- a/app/components/profiles/ProfileInfoItemWithPickerComponent.ios.js
+++ b/app/components/profiles/ProfileInfoItemWithPickerComponent.ios.js
@@ -17,7 +17,7 @@ const ProfileInfoItemWithPickerComponent = (props) => {
   const {info, playingUuid} = props;
 
   const renderPickerLabel = () => {
-    return <View style={{flexDirection: 'row', alignItems: 'center', height: '100%', marginTop: -3}}>
+    return <View style={[{flexDirection: 'row', alignItems: 'center', height: '100%'}, !props.disabled && {marginTop: -2}]}>
               {!info.value && <NoticeBadgeComponent style={{position: 'relative', width: 16, height: 16, marginRight: 6}} disableFixPosition={true}/>}
               <Text style={[styles.valueLabel, {color: props.disabled ? color.disabledColor : color.primaryColor, marginRight: 4}]}>
                 { !info.value ? props.pickerLabel : info.value }
@@ -41,15 +41,14 @@ const ProfileInfoItemWithPickerComponent = (props) => {
               pickerContentHeight={props.contentHeight}
               customPicker={renderPickerLabel()}
               showSubtitle={true}
-              subtitleStyle={{marginTop: 0}}
-              itemTextStyle={{marginTop: -2}}
+              itemTextStyle={{marginTop: -4}}
               listItemStyle={{paddingTop: 0}}
            />
   }
 
   const renderPicker = () => {
     return <React.Fragment>
-              <View style={[styles.infoWrapper, props.disabled && {height: 62}]}>
+              <View style={[styles.infoWrapper, {paddingTop: 0, height: 56}]}>
                 <Text style={[styles.label, {flex: 3}]}>{props.label}</Text>
                 { props.disabled ? <View style={[styles.valueWrapper, {flex: 8}]}>{renderPickerLabel()}</View>
                   : renderCustomPicker()
@@ -64,7 +63,7 @@ const ProfileInfoItemWithPickerComponent = (props) => {
 
     return <React.Fragment>
             <View style={styles.infoWrapper}>
-              <Text style={[styles.label, {flex: 3}]}>មុខរបរ</Text>
+              <Text style={[styles.label, {flex: 3}]}>{props.label}</Text>
               <View style={[styles.valueWrapper, {flex: 8}]}>
                 <Text style={styles.valueLabel}>{info.value}</Text>
               </View>

--- a/app/components/profiles/ProfileInfoItemWithPickerComponent.ios.js
+++ b/app/components/profiles/ProfileInfoItemWithPickerComponent.ios.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Text} from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import CustomAudioPlayerButtonComponent from '../shared/CustomAudioPlayerButtonComponent';
+import CustomBottomSheetPickerComponent from '../shared/CustomBottomSheetPickerComponent';
+import NoticeBadgeComponent from '../shared/NoticeBadgeComponent';
+import color from '../../themes/color';
+import {getStyleOfDevice} from '../../utils/responsive_util';
+import tabletStyles from '../../assets/stylesheets/tablet/profileInfoListItemComponentStyles';
+import mobileStyles from '../../assets/stylesheets/mobile/profileInfoListItemComponentStyles';
+
+const styles = getStyleOfDevice(tabletStyles, mobileStyles);
+
+const ProfileInfoItemWithPickerComponent = (props) => {
+  const {info, playingUuid} = props;
+
+  const renderPickerLabel = () => {
+    return <View style={{flexDirection: 'row', alignItems: 'center', height: '100%', marginTop: -3}}>
+              {!info.value && <NoticeBadgeComponent style={{position: 'relative', width: 16, height: 16, marginRight: 6}} disableFixPosition={true}/>}
+              <Text style={[styles.valueLabel, {color: props.disabled ? color.disabledColor : color.primaryColor, marginRight: 4}]}>
+                { !info.value ? props.pickerLabel : info.value }
+              </Text>
+              <Icon name='pencil-outline' size={22} color={props.disabled ? color.disabledColor : color.primaryColor} />
+           </View>
+  }
+
+  const renderCustomPicker = () => {
+    return <CustomBottomSheetPickerComponent
+              bottomSheetTitle={props.bottomSheetTitle}
+              items={props.items}
+              selectedItem={props.selectedValue}
+              onSelectItem={(item) => props.updateSelectedItem(item)}
+              pickerUuid={props.uuid}
+              placeholderAudio={props.placeholderAudio}
+              playingUuid={playingUuid}
+              updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+              containerStyle={[styles.valueWrapper, {flex: 8}]}
+              snapPoints={props.snapPoints}
+              pickerContentHeight={props.contentHeight}
+              customPicker={renderPickerLabel()}
+              showSubtitle={true}
+              subtitleStyle={{marginTop: 0}}
+              itemTextStyle={{marginTop: -2}}
+              listItemStyle={{paddingTop: 0}}
+           />
+  }
+
+  const renderPicker = () => {
+    return <React.Fragment>
+              <View style={[styles.infoWrapper, props.disabled && {height: 62}]}>
+                <Text style={[styles.label, {flex: 3}]}>{props.label}</Text>
+                { props.disabled ? <View style={[styles.valueWrapper, {flex: 8}]}>{renderPickerLabel()}</View>
+                  : renderCustomPicker()
+                }
+              </View>
+            </React.Fragment>
+  }
+
+  const renderContent = () => {
+    if (props.isPickerVisible)
+      return renderPicker();
+
+    return <React.Fragment>
+            <View style={styles.infoWrapper}>
+              <Text style={[styles.label, {flex: 3}]}>មុខរបរ</Text>
+              <View style={[styles.valueWrapper, {flex: 8}]}>
+                <Text style={styles.valueLabel}>{info.value}</Text>
+              </View>
+            </View>
+            <View style={styles.audioWrapper}>
+              { !!info.audio &&
+                <CustomAudioPlayerButtonComponent
+                  audio={info.audio}
+                  itemUuid={props.uuid}
+                  playingUuid={playingUuid}
+                  updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
+                />
+              }
+            </View>
+          </React.Fragment>
+  }
+
+  return <View style={[styles.container, props.containerStyle]}>
+            {renderContent()}
+         </View>
+}
+
+export default ProfileInfoItemWithPickerComponent;

--- a/app/components/profiles/ProfileInfoItemWithPickerComponent.ios.js
+++ b/app/components/profiles/ProfileInfoItemWithPickerComponent.ios.js
@@ -62,7 +62,7 @@ const ProfileInfoItemWithPickerComponent = (props) => {
       return renderPicker();
 
     return <React.Fragment>
-            <View style={styles.infoWrapper}>
+            <View style={[styles.infoWrapper, {marginBottom: getStyleOfDevice(10, 0)}]}>
               <Text style={[styles.label, {flex: 3}]}>{props.label}</Text>
               <View style={[styles.valueWrapper, {flex: 8}]}>
                 <Text style={styles.valueLabel}>{info.value}</Text>

--- a/app/components/profiles/ProfileMainComponent.android.js
+++ b/app/components/profiles/ProfileMainComponent.android.js
@@ -20,17 +20,20 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
   const dispatch = useDispatch();
   const [loggedInUser, setLoggedInUser] = React.useState(User.currentLoggedIn());
   const currentOccupation = loggedInUser.occupation;
-  const [selectedOccupation, setSelectedOccupation] = React.useState(loggedInUser.occupation);
+  const [occupation, setOccupation] = React.useState(loggedInUser.occupation);
+  const [educationLevel, setEducationLevel] = React.useState(loggedInUser.education_level);
+
   useFocusEffect(
     useCallback(() => {
-      setSelectedOccupation(loggedInUser.occupation); 
+      setOccupation(loggedInUser.occupation);
+      setEducationLevel(loggedInUser.education_level); 
       return () => {}
     }, [])
   )
 
   useImperativeHandle(ref, () => ({
     currentOccupation,
-    selectedOccupation,
+    occupation
   }))
 
   onPress = () => {
@@ -41,15 +44,15 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
   }
 
   updateProfile = () => {
-    User.update(loggedInUser.uuid, { occupation: selectedOccupation, synced: false });
+    User.update(loggedInUser.uuid, { occupation: occupation, education_level: educationLevel, synced: false });
     setLoggedInUser(User.findByUuid(loggedInUser.uuid))
-    dispatch(setLoginUserOccupation(selectedOccupation))
+    dispatch(setLoginUserOccupation(occupation))
   }
 
   renderSaveBtn = () => {
     return <React.Fragment>
               <Text style={{color: 'white', textAlign: 'center', marginBottom: 10, lineHeight: 24}}>
-                { selectedOccupation != 'n_a' ? `ដើម្បីផ្លាស់ប្ដូរមុខរបរ សូមចុច "រក្សាទុក"` : ''}
+                { (occupation != 'n_a' && educationLevel != 'n_a') ? `ដើម្បីផ្លាស់ប្ដូរមុខរបរ និងកម្រិតវប្បធម៌ សូមចុច "រក្សាទុក"` : ''}
               </Text>
               <BigButtonComponent
                 label='រក្សាទុក'
@@ -59,13 +62,13 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
                 playingUuid={props.playingUuid}
                 updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
                 onPress={() => updateProfile()}
-                disabled={selectedOccupation == 'n_a'}
+                disabled={occupation == 'n_a' || educationLevel == 'n_a'}
               />
            </React.Fragment>
   }
 
   const renderButton = () => {
-    if (currentOccupation == 'n_a')
+    if (!User.isLoginAsAnonymous() && currentOccupation == 'n_a')
       return renderSaveBtn()
 
     return <BigButtonComponent
@@ -81,8 +84,9 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
 
   return (
     <View style={{flexGrow: 1, flexDirection: 'column'}}>
-      <ProfileInfoComponent playingUuid={props.playingUuid} updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)} selectedOccupation={selectedOccupation}
-        updateSelectedOccupation={(occupation) => setSelectedOccupation(occupation)}
+      <ProfileInfoComponent playingUuid={props.playingUuid} updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)} occupation={occupation} educationLevel={educationLevel}
+        updateOccupation={(item) => setOccupation(item)}
+        updateEducationLevel={(item) => setEducationLevel(item)}
       />
       {renderButton()}
     </View>

--- a/app/components/profiles/ProfileMainComponent.ios.js
+++ b/app/components/profiles/ProfileMainComponent.ios.js
@@ -22,17 +22,20 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
   const dispatch = useDispatch();
   const [loggedInUser, setLoggedInUser] = React.useState(User.currentLoggedIn());
   const currentOccupation = loggedInUser.occupation;
-  const [selectedOccupation, setSelectedOccupation] = React.useState(loggedInUser.occupation);
+  const [occupation, setOccupation] = React.useState(loggedInUser.occupation);
+  const [educationLevel, setEducationLevel] = React.useState(loggedInUser.education_level);
+
   useFocusEffect(
     useCallback(() => {
-      setSelectedOccupation(loggedInUser.occupation); 
+      setOccupation(loggedInUser.occupation); 
+      setEducationLevel(loggedInUser.education_level); 
       return () => {}
     }, [])
   )
 
   useImperativeHandle(ref, () => ({
     currentOccupation,
-    selectedOccupation,
+    occupation,
   }))
 
   onPress = () => {
@@ -43,15 +46,15 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
   }
 
   updateProfile = () => {
-    User.update(loggedInUser.uuid, { occupation: selectedOccupation, synced: false });
+    User.update(loggedInUser.uuid, { occupation: occupation, education_level: educationLevel, synced: false });
     setLoggedInUser(User.findByUuid(loggedInUser.uuid))
-    dispatch(setLoginUserOccupation(selectedOccupation))
+    dispatch(setLoginUserOccupation(occupation))
   }
 
   const renderSaveBtn = () => {
     return <React.Fragment>
               <Text style={{color: 'white', textAlign: 'center', marginBottom: 8, lineHeight: 24}}>
-                { selectedOccupation != 'n_a' ? `ដើម្បីផ្លាស់ប្ដូរមុខរបរ សូមចុច "រក្សាទុក"` : ''}
+                { (occupation != 'n_a' && educationLevel != 'n_a') ? `ដើម្បីផ្លាស់ប្ដូរមុខរបរ និងកម្រិតវប្បធម៌ សូមចុច "រក្សាទុក"` : ''}
               </Text>
               <BigButtonComponent
                 label='រក្សាទុក'
@@ -61,13 +64,13 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
                 playingUuid={props.playingUuid}
                 updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)}
                 onPress={() => updateProfile()}
-                disabled={selectedOccupation == 'n_a'}
+                disabled={occupation == 'n_a' || educationLevel == 'n_a'}
               />
            </React.Fragment>
   }
 
   const renderButton = () => {
-    if (currentOccupation == 'n_a')
+    if (!User.isLoginAsAnonymous() && currentOccupation == 'n_a')
       return renderSaveBtn()
 
     return <BigButtonComponent
@@ -83,8 +86,9 @@ const ProfileMainComponent = React.forwardRef((props, ref) => {
 
   return (
     <View style={{flexGrow: 1, flexDirection: 'column'}}>
-      <ProfileInfoComponent playingUuid={props.playingUuid} updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)} selectedOccupation={selectedOccupation}
-        updateSelectedOccupation={(occupation) => setSelectedOccupation(occupation)}
+      <ProfileInfoComponent playingUuid={props.playingUuid} updatePlayingUuid={(uuid) => props.updatePlayingUuid(uuid)} occupation={occupation} educationLevel={educationLevel}
+        updateOccupation={(occupation) => setOccupation(occupation)}
+        updateEducationLevel={(item) => setEducationLevel(item)}
       />
       {renderButton()}
     </View>

--- a/app/components/shared/CustomBottomSheetPickerComponent.ios.js
+++ b/app/components/shared/CustomBottomSheetPickerComponent.ios.js
@@ -24,8 +24,8 @@ const CustomBottomSheetPickerComponent = (props) => {
             pickerStyle={{backgroundColor: colorSet('background')}}
             pickerBoxStyle={{paddingRight: 4}}
             bottomSheetTitleStyle={{fontSize: bottomSheetTitleFontSize, fontFamily: FontFamily.bold}}
-            placeholderStyle={[{fontSize: itemFontSize, fontFamily: FontFamily.regular, alignSelf: 'center', color: colorSet('text')}, props.placeholderStyle]}
-            itemTextStyle={[{fontSize: itemFontSize, fontFamily: FontFamily.regular}, props.itemTextStyle]}
+            placeholderStyle={[{fontSize: itemFontSize, fontFamily: FontFamily.regular, alignSelf: 'center', color: colorSet('text'), lineHeight: 30}, props.placeholderStyle]}
+            itemTextStyle={[{fontSize: itemFontSize, fontFamily: FontFamily.regular, lineHeight: 30}, props.itemTextStyle]}
             itemFontFamily={FontFamily.regular}
             pickerContentHeight={props.pickerContentHeight || defaultPickerContentHeight}
             showLeftCheckIcon={true}

--- a/app/components/shared/navigationHeaders/NavigationHeaderMenuButtonComponent.android.js
+++ b/app/components/shared/navigationHeaders/NavigationHeaderMenuButtonComponent.android.js
@@ -6,6 +6,7 @@ import {useSelector} from 'react-redux';
 import NavigationHeaderButtonComponent from './NavigationHeaderButtonComponent';
 import NoticeBadgeComponent from '../NoticeBadgeComponent';
 import color from '../../../themes/color';
+import User from '../../../models/User';
 
 const NavigationHeaderMenuButtonComponent = (props) => {
   const userOccupation = useSelector(state => state.loginUserOccupation.value)
@@ -14,7 +15,7 @@ const NavigationHeaderMenuButtonComponent = (props) => {
               <NavigationHeaderButtonComponent onPress={() => props.navigation.openDrawer()}
                 icon={<IonIcon name="reorder-two-outline" color={color.whiteColor} size={28} />}
               />
-              { userOccupation == 'n_a' && <NoticeBadgeComponent/> }
+              { (!User.isLoginAsAnonymous() && userOccupation == 'n_a') && <NoticeBadgeComponent/> }
            </View>
 }
 

--- a/app/components/shared/navigationHeaders/NavigationHeaderMenuButtonComponent.ios.js
+++ b/app/components/shared/navigationHeaders/NavigationHeaderMenuButtonComponent.ios.js
@@ -6,6 +6,7 @@ import {useSelector} from 'react-redux';
 import NavigationHeaderButtonComponent from './NavigationHeaderButtonComponent';
 import NoticeBadgeComponent from '../NoticeBadgeComponent';
 import color from '../../../themes/color';
+import User from '../../../models/User';
 
 const NavigationHeaderMenuButtonComponent = (props) => {
   const userOccupation = useSelector(state => state.loginUserOccupation.value)
@@ -14,7 +15,7 @@ const NavigationHeaderMenuButtonComponent = (props) => {
               <NavigationHeaderButtonComponent onPress={() => props.navigation.openDrawer()}
                 icon={<IonIcon name="reorder-two-outline" color={color.whiteColor} size={28} />}
               />
-              { userOccupation == 'n_a' && <NoticeBadgeComponent/> }
+              { (!User.isLoginAsAnonymous() && userOccupation == 'n_a') && <NoticeBadgeComponent/> }
            </View>
 }
 

--- a/app/constants/modal_constant.js
+++ b/app/constants/modal_constant.js
@@ -17,10 +17,12 @@ export const signUpConfirmationContentHeight = Platform.OS == 'ios' ? getStyleOf
 export const videoFilterSnapPoints = getStyleOfDevice(['52%'], ['65%']);
 export const videoFilterContentHeight = getStyleOfDevice(hp('47%'), hp('60%'));
 
-export const androidOccupationSnapPoints = isShortScreenDevice() ? ['80.5%'] : ['65.6%'];
-export const androidOccupationContentHeight = isShortScreenDevice() ? 512 : 458;
-export const iosOccupationSnapPoints = DeviceInfo.hasNotch() ? ['66%'] : isShortScreenDevice() ? ['79%'] : ['72%'];
-export const iosOccupationContentHeight = DeviceInfo.hasNotch() ? 490 : isShortScreenDevice() ? 500 : 500;
+export const androidOccupationSnapPoints = isShortScreenDevice() ? ['72.8%'] : ['65.6%'];
+export const androidOccupationContentHeight = isShortScreenDevice() ? 455 : 458;
+export const iosOccupationSnapPoints = DeviceInfo.hasNotch() ? ['60%'] : isShortScreenDevice() ? ['71%'] : ['65%'];
+export const iosOccupationContentHeight = DeviceInfo.hasNotch() ? 452 : isShortScreenDevice() ? 450 : 454;
 
-export const androidEducationLevelSnapPoints = isShortScreenDevice() ? ['80.5%'] : ['48%'];
-export const androidEducationLevelContentHeight = isShortScreenDevice() ? 512 : 329;
+export const androidEducationLevelSnapPoints = isShortScreenDevice() ? ['54%'] : ['48%'];
+export const androidEducationLevelContentHeight = isShortScreenDevice() ? 327 : 329;
+export const iosEducationLevelSnapPoints = DeviceInfo.hasNotch() ? ['45%'] : isShortScreenDevice() ? ['52%'] : ['48%'];
+export const iosEducationLevelContentHeight = DeviceInfo.hasNotch() ? 325 : isShortScreenDevice() ? 322 : 325;

--- a/app/constants/modal_constant.js
+++ b/app/constants/modal_constant.js
@@ -19,10 +19,10 @@ export const videoFilterContentHeight = getStyleOfDevice(hp('47%'), hp('60%'));
 
 export const androidOccupationSnapPoints = isShortScreenDevice() ? ['72.8%'] : ['65.6%'];
 export const androidOccupationContentHeight = isShortScreenDevice() ? 455 : 458;
-export const iosOccupationSnapPoints = DeviceInfo.hasNotch() ? ['60%'] : isShortScreenDevice() ? ['71%'] : ['65%'];
-export const iosOccupationContentHeight = DeviceInfo.hasNotch() ? 452 : isShortScreenDevice() ? 450 : 454;
+export const iosOccupationSnapPoints = getStyleOfDevice(['45%'], DeviceInfo.hasNotch() ? ['60%'] : isShortScreenDevice() ? ['71%'] : ['65%']);
+export const iosOccupationContentHeight = getStyleOfDevice( 440, DeviceInfo.hasNotch() ? 452 : isShortScreenDevice() ? 450 : 454);
 
 export const androidEducationLevelSnapPoints = isShortScreenDevice() ? ['54%'] : ['48%'];
 export const androidEducationLevelContentHeight = isShortScreenDevice() ? 327 : 329;
-export const iosEducationLevelSnapPoints = DeviceInfo.hasNotch() ? ['45%'] : isShortScreenDevice() ? ['52%'] : ['48%'];
-export const iosEducationLevelContentHeight = DeviceInfo.hasNotch() ? 325 : isShortScreenDevice() ? 322 : 325;
+export const iosEducationLevelSnapPoints = getStyleOfDevice(['34%'], DeviceInfo.hasNotch() ? ['45%'] : isShortScreenDevice() ? ['52%'] : ['48%']);
+export const iosEducationLevelContentHeight = getStyleOfDevice(320, DeviceInfo.hasNotch() ? 325 : isShortScreenDevice() ? 322 : 325);

--- a/app/constants/modal_constant.js
+++ b/app/constants/modal_constant.js
@@ -17,7 +17,10 @@ export const signUpConfirmationContentHeight = Platform.OS == 'ios' ? getStyleOf
 export const videoFilterSnapPoints = getStyleOfDevice(['52%'], ['65%']);
 export const videoFilterContentHeight = getStyleOfDevice(hp('47%'), hp('60%'));
 
-export const androidOccupationSnapPoints = isShortScreenDevice() ? ['80.5%'] : ['72%'];
-export const androidOccupationContentHeight = isShortScreenDevice() ? 512 : 522;
+export const androidOccupationSnapPoints = isShortScreenDevice() ? ['80.5%'] : ['65.6%'];
+export const androidOccupationContentHeight = isShortScreenDevice() ? 512 : 458;
 export const iosOccupationSnapPoints = DeviceInfo.hasNotch() ? ['66%'] : isShortScreenDevice() ? ['79%'] : ['72%'];
 export const iosOccupationContentHeight = DeviceInfo.hasNotch() ? 490 : isShortScreenDevice() ? 500 : 500;
+
+export const androidEducationLevelSnapPoints = isShortScreenDevice() ? ['80.5%'] : ['48%'];
+export const androidEducationLevelContentHeight = isShortScreenDevice() ? 512 : 329;

--- a/app/constants/modal_constant.js
+++ b/app/constants/modal_constant.js
@@ -17,12 +17,12 @@ export const signUpConfirmationContentHeight = Platform.OS == 'ios' ? getStyleOf
 export const videoFilterSnapPoints = getStyleOfDevice(['52%'], ['65%']);
 export const videoFilterContentHeight = getStyleOfDevice(hp('47%'), hp('60%'));
 
-export const androidOccupationSnapPoints = isShortScreenDevice() ? ['72.8%'] : ['65.6%'];
-export const androidOccupationContentHeight = isShortScreenDevice() ? 455 : 458;
+export const androidOccupationSnapPoints = getStyleOfDevice(['55%'], isShortScreenDevice() ? ['72.8%'] : ['65.6%']);
+export const androidOccupationContentHeight = getStyleOfDevice(462, isShortScreenDevice() ? 455 : 458);
 export const iosOccupationSnapPoints = getStyleOfDevice(['45%'], DeviceInfo.hasNotch() ? ['60%'] : isShortScreenDevice() ? ['71%'] : ['65%']);
 export const iosOccupationContentHeight = getStyleOfDevice( 440, DeviceInfo.hasNotch() ? 452 : isShortScreenDevice() ? 450 : 454);
 
-export const androidEducationLevelSnapPoints = isShortScreenDevice() ? ['54%'] : ['48%'];
-export const androidEducationLevelContentHeight = isShortScreenDevice() ? 327 : 329;
+export const androidEducationLevelSnapPoints = getStyleOfDevice(['40%'], isShortScreenDevice() ? ['54%'] : ['48%']);
+export const androidEducationLevelContentHeight = getStyleOfDevice(333, isShortScreenDevice() ? 327 : 329);
 export const iosEducationLevelSnapPoints = getStyleOfDevice(['34%'], DeviceInfo.hasNotch() ? ['45%'] : isShortScreenDevice() ? ['52%'] : ['48%']);
 export const iosEducationLevelContentHeight = getStyleOfDevice(320, DeviceInfo.hasNotch() ? 325 : isShortScreenDevice() ? 322 : 325);

--- a/app/constants/user_constant.js
+++ b/app/constants/user_constant.js
@@ -22,6 +22,18 @@ export const anonymousInfo = [
     audio: null,
   },
   {
+    uuid: 'user-occupation',
+    label: 'មុខរបរ',
+    value: 'អនាមិក',
+    audio: null,
+  },
+  {
+    uuid: 'user-education_level',
+    label: 'កម្រិតវប្បធម៌',
+    value: 'អនាមិក',
+    audio: null,
+  },
+  {
     uuid: 'user-characteristic',
     label: 'ស្ថានភាពរស់នៅ',
     value: 'អនាមិក',

--- a/app/db/data/educations.js
+++ b/app/db/data/educations.js
@@ -1,0 +1,34 @@
+export default [
+  {
+    "uuid":"education_1",
+    "value": "general_knowledge",
+    "name_km": "ចំណេះដឹងទូទៅ",
+    "name_en": "General knowledge",
+    "audio": null,
+    "subtitle": "សិស្សិបឋមសិក្សា, អនុវិទ្យាល័យ, វិទ្យាល័យ"
+  },
+  {
+    "uuid":"education_2",
+    "value": "university",
+    "name_km": "បរិញ្ញាបត្រ/បរិញ្ញាបត្ររង",
+    "name_en": "Bachelor Degree/Associate Degree",
+    "audio": null,
+    "subtitle": "និស្សិតមហាវិទ្យាល័យ, សាកលវិទ្យាល័យ"
+  },
+  {
+    "uuid":"education_3",
+    "value": "tvet",
+    "name_km": "TVET",
+    "name_en": "TVET",
+    "audio": null,
+    "subtitle": "អ្នករៀនជំនាញបច្ចេកទេស និងវិជ្ជាជីវៈ"
+  },
+  {
+    "uuid":"education_4",
+    "value": "dropout_student",
+    "name_km": "បោះបង់ការសិក្សា (ឈប់រៀន)",
+    "name_en": "Dropout student",
+    "audio": null,
+    "subtitle": "មិនបានបញ្ចប់ថ្នាក់ទី១២"
+  },
+];

--- a/app/db/data/occupations.js
+++ b/app/db/data/occupations.js
@@ -5,18 +5,10 @@ export default [
     "name_km": "សិស្ស/និស្សិត",
     "name_en": "Student",
     "audio": null,
-    "subtitle": "អនុវិទ្យាល័យ, វិទ្យាល័យ, សាកលវិទ្យាល័យ"
+    "subtitle": ""
   },
   {
     "uuid":"occupation_2",
-    "value": "dropout_student",
-    "name_km": "បោះបង់ការសិក្សា (ឈប់រៀន)",
-    "name_en": "Dropout student",
-    "audio": null,
-    "subtitle": "អ្នកដែលរៀនក្រៅសាលា"
-  },
-  {
-    "uuid":"occupation_3",
     "value": "entertainment_worker",
     "name_km": "បុគ្គលិកសេវាកំសាន្ត",
     "name_en": "Entertainment worker",
@@ -24,7 +16,7 @@ export default [
     "subtitle": "បុគ្គលិកបៀរហ្គាឌិន, ខារ៉ាអូខេ, កន្លែងម៉ាស្សា, ..."
   },
   {
-    "uuid":"occupation_4",
+    "uuid":"occupation_3",
     "value": "factory_worker",
     "name_km": "បុគ្គលិករោងចក្រ",
     "name_en": "Factory worker",
@@ -32,15 +24,15 @@ export default [
     "subtitle": "រោងចក្រកាត់ដេរសំលៀកបំពាក់, ស្បែកជើង, ..."
   },
   {
-    "uuid":"occupation_5",
+    "uuid":"occupation_4",
     "value": "local_migrant_worker",
     "name_km": "កម្មករចំណាកស្រុក (ក្នុងប្រទេស)",
     "name_en": "Migrant worker (Local)",
     "audio": null,
-    "subtitle": "ចំណាកស្រុកធ្វើការឆ្លងខេត្ត"
+    "subtitle": "ចំណាកស្រុកធ្វើការឆ្លងស្រុក ឬខេត្ត"
   },
   {
-    "uuid":"occupation_6",
+    "uuid":"occupation_5",
     "value": "oversea_migrant_worker",
     "name_km": "កម្មករចំណាកស្រុក (ក្រៅប្រទេស)",
     "name_en": "Migrant worker (Oversea)",

--- a/app/db/migrations/v7/user.js
+++ b/app/db/migrations/v7/user.js
@@ -14,7 +14,8 @@ const UserSchema = {
     synced: { type: 'bool', default: false },
     logged_in: { type: 'bool', default: true },
     anonymous: { type: 'bool', default: false },
-    occupation: 'string?'
+    occupation: 'string?',
+    education_level: 'string?'
   }
 }
 

--- a/app/db/schemas/schemaV8.js
+++ b/app/db/schemas/schemaV8.js
@@ -24,8 +24,9 @@ const schemaV8 = {
       const oldObjects = oldRealm.objects('User');
       const newObjects = newRealm.objects('User');
       for (let i = 0; i < oldObjects.length; i++) {
-        // if the user is anonymous the occupation is set to null
+        // if the user is anonymous the occupation and education_level are set to null
         newObjects[i].occupation = oldObjects[i].age == -1 ? null : !oldObjects[i].occupation ? 'n_a' : oldObjects[i].occupation;
+        newObjects[i].education_level = oldObjects[i].age == -1 ? null : !oldObjects[i].education_level ? 'n_a' : oldObjects[i].education_level;
         newObjects[i].synced = false;
       }
     }

--- a/app/db/schemas/schemaV8.js
+++ b/app/db/schemas/schemaV8.js
@@ -24,9 +24,9 @@ const schemaV8 = {
       const oldObjects = oldRealm.objects('User');
       const newObjects = newRealm.objects('User');
       for (let i = 0; i < oldObjects.length; i++) {
-        // if the user is anonymous the occupation and education_level are set to null
-        newObjects[i].occupation = oldObjects[i].age == -1 ? null : !oldObjects[i].occupation ? 'n_a' : oldObjects[i].occupation;
-        newObjects[i].education_level = oldObjects[i].age == -1 ? null : !oldObjects[i].education_level ? 'n_a' : oldObjects[i].education_level;
+        // if the user is anonymous the occupation and education_level are set to n_a
+        newObjects[i].occupation = oldObjects[i].age == -1 ? 'n_a' : !oldObjects[i].occupation ? 'n_a' : oldObjects[i].occupation;
+        newObjects[i].education_level = oldObjects[i].age == -1 ? 'n_a' : !oldObjects[i].education_level ? 'n_a' : oldObjects[i].education_level;
         newObjects[i].synced = false;
       }
     }

--- a/app/helpers/profile_helper.js
+++ b/app/helpers/profile_helper.js
@@ -2,6 +2,7 @@ import genders from '../db/data/genders';
 import provinces from '../db/data/provinces';
 import characteristics from '../db/data/characteristics';
 import occupations from '../db/data/occupations';
+import educations from '../db/data/educations';
 
 const profileHelper = (() => {
   return {
@@ -9,6 +10,7 @@ const profileHelper = (() => {
     getProvince,
     getCharacteristic,
     getOccupation,
+    getEducation
   }
 
   function getGender(value) {
@@ -25,6 +27,10 @@ const profileHelper = (() => {
 
   function getOccupation(value) {
     return occupations.find(occupation => occupation.value == value)
+  }
+
+  function getEducation(value) {
+    return educations.find(education => education.value == value)
   }
 })()
 

--- a/app/helpers/user_helper.js
+++ b/app/helpers/user_helper.js
@@ -36,6 +36,8 @@ const userHelper = (() => {
   }
 
   function getEducationDataset(language, occupation) {
+    if (occupation == 'n_a') return [];
+
     return _getPickerDataset(occupation == 'student' ? educations.slice(0, -1) : educations, language);
   }
 

--- a/app/helpers/user_helper.js
+++ b/app/helpers/user_helper.js
@@ -35,8 +35,8 @@ const userHelper = (() => {
     return _getPickerDataset(occupations, language);
   }
 
-  function getEducationDataset(language) {
-    return _getPickerDataset(educations, language);
+  function getEducationDataset(language, occupation) {
+    return _getPickerDataset(occupation == 'student' ? educations.slice(0, -1) : educations, language);
   }
 
   // private method

--- a/app/helpers/user_helper.js
+++ b/app/helpers/user_helper.js
@@ -3,6 +3,7 @@ import arrayUtil from '../utils/array_util';
 import provinces from '../db/data/provinces';
 import characteristics from '../db/data/characteristics';
 import occupations from '../db/data/occupations';
+import educations from '../db/data/educations';
 
 const userHelper = (() => {
   return {
@@ -10,6 +11,7 @@ const userHelper = (() => {
     getProvinceDataset,
     getCharacteristicDataset,
     getOccupationDataset,
+    getEducationDataset,
   }
 
   function getAgeDataset(postfix) {
@@ -31,6 +33,10 @@ const userHelper = (() => {
 
   function getOccupationDataset(language) {
     return _getPickerDataset(occupations, language);
+  }
+
+  function getEducationDataset(language) {
+    return _getPickerDataset(educations, language);
   }
 
   // private method

--- a/app/localizations/en.json
+++ b/app/localizations/en.json
@@ -94,8 +94,5 @@
   "noResult": "No result",
   "filterClinic": "Filter Clinic",
   "search": "Search",
-  "hour": "h",
-  "occupation": "Occupation",
-  "selectYourOccupation": "Select your occupation",
-  "yourOccupaton": "Your occupation"
+  "hour": "h"
 }

--- a/app/localizations/km.json
+++ b/app/localizations/km.json
@@ -94,8 +94,5 @@
   "noResult": "មិនមានលទ្ធផល",
   "filterClinic": "ស្វែងរកគ្លីនិក",
   "search": "ស្វែងរក",
-  "hour": "ម៉ោង",
-  "occupation": "មុខរបរ",
-  "selectYourOccupation": "ជ្រើសរើសមុខរបររបស់អ្នក",
-  "yourOccupaton": "មុខរបររបស់អ្នក"
+  "hour": "ម៉ោង"
 }

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -23,6 +23,10 @@ class User {
     return BaseModel.findByAttr(MODEL, {logged_in: true})[0];
   }
 
+  static isLoginAsAnonymous = () => {
+    return BaseModel.findByAttr(MODEL, {logged_in: true})[0].age == -1;
+  }
+
   static hasCurrentLoggedIn = () => {
     return !!this.currentLoggedIn();
   }

--- a/app/services/app_user_service.js
+++ b/app/services/app_user_service.js
@@ -60,7 +60,7 @@ const createAccountService = (() => {
     networkService.checkConnection(async () => {
       let response = null;
       if (!!params.id)
-        response = await new AppUserApi().put(params.id, { device_id: await DeviceInfo.getUniqueId(), occupation: params.occupation });
+        response = await new AppUserApi().put(params.id, { device_id: await DeviceInfo.getUniqueId(), occupation: params.occupation, education_level: params.education_level });
       else
         response = await new AppUserApi().post(await _userApiParams(params));
 
@@ -80,8 +80,8 @@ const createAccountService = (() => {
       gender: user ? user.gender : null,
       age: user ? user.age : -1,
       province_id: user ? user.province_id : null,
-      occupation: user ? user.occupation : null,
-      education_level: user ? user.education_level : null,
+      occupation: user ? user.occupation : 'n_a',
+      education_level: user ? user.education_level : 'n_a',
       registered_at: Moment().toDate(),
       characteristics: user ? user.characteristics : [],
       synced: false,
@@ -103,6 +103,7 @@ const createAccountService = (() => {
       registered_at: user.registered_at,
       province_id: user.province_id,
       occupation: user.occupation,
+      education_level: user.education_level,
       gender: user.gender,
       age: user.age,
       platform: Platform.OS

--- a/app/services/app_user_service.js
+++ b/app/services/app_user_service.js
@@ -25,8 +25,8 @@ const createAccountService = (() => {
     appVisitService.updateAppVisitsWithoutUser(params.uuid);  // update user uuid to app_visit
   }
 
-  function isValidForm(age, province, occupation) {
-    return age > 0 && !!province && !!occupation;
+  function isValidForm(age, province, occupation, educationLevel) {
+    return age > 0 && !!province && !!occupation && !!educationLevel;
   }
 
   function createAnonymousUser() {

--- a/app/services/app_user_service.js
+++ b/app/services/app_user_service.js
@@ -81,6 +81,7 @@ const createAccountService = (() => {
       age: user ? user.age : -1,
       province_id: user ? user.province_id : null,
       occupation: user ? user.occupation : null,
+      education_level: user ? user.education_level : null,
       registered_at: Moment().toDate(),
       characteristics: user ? user.characteristics : [],
       synced: false,

--- a/app/views/profiles/ProfileView.android.js
+++ b/app/views/profiles/ProfileView.android.js
@@ -44,7 +44,7 @@ const ProfileView = () => {
   }
 
   const onPress = () => {
-    if (profileRef.current?.currentOccupation != profileRef.current?.selectedOccupation)
+    if (profileRef.current?.currentOccupation != profileRef.current?.occupation)
       return setVisible(true)
 
     onBackPress()

--- a/app/views/profiles/ProfileView.ios.js
+++ b/app/views/profiles/ProfileView.ios.js
@@ -44,7 +44,7 @@ const ProfileView = () => {
   }
 
   const onPress = () => {
-    if (profileRef.current?.currentOccupation != profileRef.current?.selectedOccupation)
+    if (profileRef.current?.currentOccupation != profileRef.current?.occupation)
       return setVisible(true)
 
     onBackPress()


### PR DESCRIPTION
This pull request adds the education level picker to the registration form and makes some updates as listed below:
- Migrate the education_level and occupation of the existing user (from the previous version) as 'n_a'
- Set the education_level of the anonymous user as 'n_a'
- Add the education level picker in the profile screen to allow the user to update their profile (when updated from the previous version)
- Include education_level when submitting the user to the server

Below are the screenshots of the updated occupation and education level picker and the profile screen on iOS and Android devices:
[education level.zip](https://github.com/kawsangs/adolescents_app/files/12167620/education.level.zip)

