### PR TITLE
Increase option of the age picker to 99 years old

### DIFF
--- a/App.ios.js
+++ b/App.ios.js
@@ -16,6 +16,7 @@ import {useTranslation} from 'react-i18next';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
 import FeatherIcon from 'react-native-vector-icons/Feather';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import AppNavigator from './app/navigators/app_navigator';
 import i18nextInit from './app/localizations/i18next';

--- a/app/constants/user_constant.js
+++ b/app/constants/user_constant.js
@@ -1,5 +1,5 @@
 export const minimumAge = 13;
-export const maximumAge = 51;
+export const maximumAge = 99;
 
 
 export const anonymousInfo = [


### PR DESCRIPTION
This pull request increases the range of the age picker to 99 years old and fixes the error caused by not importing AsyncStorge for iOS.

<img src="https://github.com/kawsangs/adolescents_app/assets/18114944/2d893013-dd8e-4d6e-8602-f4a191839ebb" width="250" height="550"/>
