### PR TITLE
Update the Android targetSdkVersion from 31 to 33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,10 +4,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64


### PR DESCRIPTION
This pull request updates the Android targetSdkVersion from 31 to 33 to resolve the requirement of the Google Play Console.