### PR TITLE
Prevent the Android toast message showing mutiple times

### DIFF
--- a/app/helpers/system_back_button_helper.js
+++ b/app/helpers/system_back_button_helper.js
@@ -13,6 +13,7 @@ const systemBackButtonHelper = (() => {
 
   function handleBackToExitApp(message) {
     let lastPress = null;
+    let isToastVisible = false;
 
     return BackHandler.addEventListener('hardwareBackPress', () => {
       const currentScreen = navigationRef.current?.getCurrentRoute().name.toLowerCase();
@@ -25,8 +26,13 @@ const systemBackButtonHelper = (() => {
 
       if (lastPress && (now - lastPress) < DOUBLE_PRESS_DELAY)
         return false;
-      else
+      else if (!isToastVisible) {
         toastMessageHelper.showMessage(message);
+        isToastVisible = true;
+        setTimeout(() => {
+          isToastVisible = false;
+        }, 2500);
+      }
 
       lastPress = now;
       return true;


### PR DESCRIPTION
This pull request prevents the Android toast message from showing multiple times when the user presses the Android back button multiple times on the home screen. It also prevents multiple toast messages from appearing when the app is closed or quitting.